### PR TITLE
fix(token_caching): Adjust API Auth to refresh expired tokens

### DIFF
--- a/staxapp/api.py
+++ b/staxapp/api.py
@@ -26,10 +26,8 @@ class Api:
     @classmethod
     def _auth(cls, **kwargs):
         if not cls._requests_auth:
-            cls._requests_auth = Config.get_auth_class().requests_auth(
-                Config.access_key, Config.secret_key, **kwargs
-            )
-        return cls._requests_auth
+            cls._requests_auth = Config.get_auth_class().requests_auth
+        return cls._requests_auth(Config.access_key, Config.secret_key, **kwargs)
 
     @staticmethod
     def handle_api_response(response):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,11 +20,21 @@ class StaxApiTests(unittest.TestCase):
 
     def setUp(self):
         self.Api = Api
-        self.Api._requests_auth = ("username", "password")
+        self.Api._requests_auth = lambda x, y: (x, y)
 
     def testAuth(self):
+
+        Config.access_key = "1"
+        Config.secret_key = "2"
+
         auth = self.Api._auth()
-        self.assertEqual(self.Api._requests_auth, auth)
+        self.assertEqual(self.Api._requests_auth("1", "2"), auth)
+
+        Config.access_key = "3"
+        Config.secret_key = "4"
+
+        auth = self.Api._auth()
+        self.assertEqual(self.Api._requests_auth("3", "4"), auth)
 
     @responses.activate
     def testGet(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -21,7 +21,7 @@ class StaxClientTests(unittest.TestCase):
 
     def setUp(self):
         self.Api = Api
-        self.Api._requests_auth = ("username", "password")
+        self.Api._requests_auth = lambda x, y: (x, y)
 
         self.account_client = StaxClient("accounts")
         self.workload_client = StaxClient("workloads")


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Bug Fix

* **What is the current behavior?**
After 1 hour the sdk will start generating 403 errors, as the initial credentials have expired.

* **Does this PR introduce a breaking change?**
This will only introduce problems if Api._requests_auth is being accessed directly.
