### PR TITLE
fix(invalid_token): Retry cognito signed token issues

### DIFF
--- a/staxapp/auth.py
+++ b/staxapp/auth.py
@@ -101,7 +101,7 @@ class StaxAuth:
                 )
                 break
             except ClientError as e:
-                # AWS will occasionally issue invalid tokens, attempt to retry up to 3 times
+                # AWS eventual consistency, attempt to retry up to 3 times
                 if "Couldn't verify signed token" in str(e):
                     continue
                 else:


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Bug fix

* **What is the current behavior?**
There must be some eventual consistency issue with AWS and issuing a Cognito token, after issuing a new Cognito token when we call Cognito.get_id we occasionally receive a NotAuthorizedException with the message "Invalid login token. Couldn't verify signed token." Simply retrying the same call with the same token works without issue.

* **Does this PR introduce a breaking change?**
No breaking changes.
