### PR TITLE
feat(sdk): remove pycrypto and general package cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ test: lint
 install:
 	python3 -m venv ${VIRTUAL_ENV}
 	${PIP} install -r requirements.txt
+	${PYTHON} setup.py install
 
 lint: install
 	${ISORT} --diff staxapp/*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ isort
 jsonschema
 pyjwt
 nose2
-openapi-spec-validator
 prance
 pycodestyle
 pylint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-aws_requests_auth
 black
-boto3
 isort
 jsonschema
 pyjwt
@@ -8,10 +6,7 @@ nose2
 openapi-spec-validator
 prance
 pycodestyle
-pycrypto
 pylint
 pytest
 pytest-cov
-requests
 responses
-warrant

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ requires = [
     "requests",
     "aws_requests_auth",
     "warrant",
-    "pycrypto",
     "pyjwt",
     "openapi-spec-validator",
 ]


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* remove pycrypto since it's redundant #60 
* cleanup deps in general
* unit test now installs from setup.py so we're testing dependancies

**What is the current behavior?** (You can also link to an open issue here)

* install pycrypto (in setup.py and requirements.txt)
* requirements.txt is both dev deps and a duplicate of setup.py

**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* no - if anything it reduces the number of packages users will be pulling down.