### PR TITLE
fix(sdk): set openapi-spec-validator==0.2.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ responses
 pyjwt==1.7.1
 boto3
 aws_requests_auth
-openapi-spec-validator
+openapi-spec-validator==0.2.9


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Bug fix

* **What is the current behavior?**
Latest version of openapi-spec-validator has introduced stricter schema validation which currently fails against the api-document, we need to ensure we only use 0.2.9

* **Does this PR introduce a breaking change?**
When using openapi-spec-validator > 0.2.9 schema validation will fail
