### PR TITLE
fix(sdk): set openapi-spec-validator==0.2.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requires = [
     "prance",
     "requests",
     "aws_requests_auth",
-    "openapi-spec-validator",
+    "openapi-spec-validator==0.2.9",
 ]
 
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** 
Bug fix

* **What is the current behavior?**
Latest version of openapi-spec-validator has introduced stricter schema validation which currently fails against the api-document, we need to ensure we only use 0.2.9

* **Does this PR introduce a breaking change?**
When using openapi-spec-validator > 0.2.9 schema validation will fail
