### PR TITLE
chore(security): update the codecov action to a fixed sha

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Run tests
         run: make test
       - name: Upload coverage to Codecov 📝
-        uses: "codecov/codecov-action@v1"
+        # https://github.com/codecov/codecov-action codecov/1.4.0
+        # Pinned this to a git sha as per recommendations in GitHub actions hardening guide.
+        # see https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
+        uses: "codecov/codecov-action@0e28ff86a50029a44d10df6ed4c308711925a6a8" 
         with:
           fail_ci_if_error: true
           file: ./coverage-reports/coverage-report.xml


### PR DESCRIPTION
This change will ensure the latest update for the action is used and pin this version.

This is in line with the GitHub actions hardening guide https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions.