### PR TITLE
ci(UnitTests): reduce coverage report to staxapp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help:
 	@echo "       run black"
 
 test: lint
-	PYTHONPATH=$(CURRENT_DIRECTORY) ${PYTHON} -m pytest --cov=. --cov-config=.coveragerc --cov-report term-missing tests/ --junitxml=coverage-reports/test-report.xml --cov-report xml:coverage-reports/coverage-report.xml
+	PYTHONPATH=$(CURRENT_DIRECTORY) ${PYTHON} -m pytest --cov=staxapp --cov-config=.coveragerc --cov-report term-missing tests/ --junitxml=coverage-reports/test-report.xml --cov-report xml:coverage-reports/coverage-report.xml
 
 install:
 	python3 -m venv ${VIRTUAL_ENV}


### PR DESCRIPTION
Coverage report providing coverage for all libraries.

This provides crisp list
![image](https://user-images.githubusercontent.com/17537115/115176371-560a5b00-a110-11eb-81f1-9ea04a315034.png)
