### PR TITLE
feat(ApiAuth): reduce probability of token expiry moments after retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ export STAX_ACCESS_KEY=<your_access_key>
 export STAX_SECRET_KEY=<your_secret_key>
 ```
 
+*Optional configuration:*
+
+##### Authentication token expiry
+
+Allows configuration of the threshold to when the Auth library should re-cache the credentials
+*Suggested use when running within CI/CD tools to reduce overall auth calls*
+~~~bash
+export TOKEN_EXPIRY_THRESHOLD_IN_MINS=2 # Type: Integer representing minutes
+~~~
+
 ## Usage
 
 ### Read Accounts

--- a/staxapp/auth.py
+++ b/staxapp/auth.py
@@ -1,5 +1,5 @@
 #!/usr/local/bin/python3
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import boto3
 from aws_requests_auth.aws_auth import AWSRequestsAuth
@@ -139,7 +139,10 @@ class RootAuth:
 class ApiTokenAuth:
     @staticmethod
     def requests_auth(username, password, **kwargs):
-        if StaxConfig.expiration and StaxConfig.expiration > datetime.now(timezone.utc):
+        # Minimize the potentical for token to expire while still being used for auth (say within a lambda function)
+        if StaxConfig.expiration and StaxConfig.expiration - timedelta(
+            minutes=10
+        ) > datetime.now(timezone.utc):
             return StaxConfig.auth
 
         return StaxAuth("ApiAuth").requests_auth(username, password, **kwargs)

--- a/staxapp/auth.py
+++ b/staxapp/auth.py
@@ -1,5 +1,6 @@
 #!/usr/local/bin/python3
 from datetime import datetime, timedelta, timezone
+from os import environ
 
 import boto3
 from aws_requests_auth.aws_auth import AWSRequestsAuth
@@ -141,7 +142,7 @@ class ApiTokenAuth:
     def requests_auth(username, password, **kwargs):
         # Minimize the potentical for token to expire while still being used for auth (say within a lambda function)
         if StaxConfig.expiration and StaxConfig.expiration - timedelta(
-            minutes=10
+            minutes=int(environ.get("TOKEN_EXPIRY_THRESHOLD_IN_MINS", 1))
         ) > datetime.now(timezone.utc):
             return StaxConfig.auth
 

--- a/staxapp/data/schema.json
+++ b/staxapp/data/schema.json
@@ -1,8640 +1,11211 @@
 {
-    "components": {
-        "requestBodies": {},
-        "responses": {},
-        "schemas": {
-            "Account": {
-                "properties": {
-                    "AWSLoginURLs": {
-                        "properties": {
-                            "admin": {"type": "string"},
-                            "developer": {"type": "string"},
-                            "readonly": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "AccountType": {"type": "string"},
-                    "AllocatedTS": {
-                        "description": "Allocated timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "AssuranceState": {
-                        "description": "Hardening state of the Account.",
-                        "enum": ["NONE", "UPDATING", "ACTIVE", "ERROR"],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "AssuranceStateReason": {
-                        "description": "Descriptive reason for the current AssuranceState.",
-                        "example": "AWS GuardDuty Hardening has failed",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "AwsAccountId": {
-                        "description": "AWS Account Id.",
-                        "example": "012345678901",
-                        "maxLength": 12,
-                        "minLength": 12,
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "AwsAccountStatusId": {"type": "string"},
-                    "AwsLoginURL": {"type": "string"},
-                    "CreatedBy": {
-                        "description": "UUID of the account creator.",
-                        "example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-                        "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Email": {
-                        "description": "Email address of account owner.",
-                        "example": "stax.user@example.com",
-                        "format": "email",
-                        "maxLength": 128,
-                        "minLength": 6,
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "LatestCost": {
-                        "example": 72.52,
-                        "readOnly": true,
-                        "type": "number",
-                    },
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2019-03-11T01:11:40.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Account.",
-                        "example": "bakery",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "OrgsOuId": {"type": "string"},
-                    "Origin": {
-                        "description": "Origin of the Account.",
-                        "enum": ["STAX", "External"],
-                        "example": "STAX",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Status": {
-                        "description": "Status of the Account.",
-                        "enum": [
-                            "ACTIVE",
-                            "AWSERROR",
-                            "CLOSED",
-                            "DISCOVERED",
-                            "ERROR",
-                            "INITIALIZING",
-                            "MAINTENANCE",
-                            "NEW",
-                            "NOAWS",
-                            "SUSPENDED",
-                        ],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "StaxCreated": {"type": "boolean"},
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "required": ["OrganisationId", "Name"],
-                "type": "object",
-            },
-            "AccountTask": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseTask"}],
-                "properties": {
-                    "Accounts": {
-                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "AccountType": {
-                "properties": {
-                    "Accounts": {"example": [], "type": "array"},
-                    "CreatedBy": {
-                        "description": "UUID of the account creator.",
-                        "example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-                        "nullable": true,
-                        "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of Account Type.",
-                        "example": "Development",
-                        "maxLength": 64,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Policies": {"example": [], "type": "array"},
-                    "Roles": {"example": [], "type": "array"},
-                    "Status": {"enum": ["ACTIVE", "DELETED"], "example": "ACTIVE"},
-                    "StaxCreated": {"type": "boolean"},
-                },
-                "required": ["OrganisationId", "Name"],
-                "type": "object",
-            },
-            "AccountTypeAccessMap": {
-                "additionalProperties": false,
-                "anyOf": [
-                    {"required": ["AccountTypeId", "GroupId", "RoleName"]},
-                    {"required": ["AccountTypeName", "GroupId", "RoleName"]},
-                    {"required": ["AccountTypeId", "GroupName", "RoleName"]},
-                    {"required": ["AccountTypeName", "GroupName", "RoleName"]},
-                ],
-                "properties": {
-                    "AccountTypeId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "AccountTypeName": {"type": "string"},
-                    "GroupId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "GroupName": {"type": "string"},
-                    "RoleName": {"$ref": "#\/components\/schemas\/AwsAccessRole"},
-                },
-                "type": "object",
-            },
-            "AccountTypeMemberMap": {
-                "additionalProperties": false,
-                "anyOf": [
-                    {"required": ["AccountTypeId", "AccountId"]},
-                    {"required": ["AccountTypeName", "AccountId"]},
-                ],
-                "properties": {
-                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "AccountTypeId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "AccountTypeName": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "AccountTypePolicyMap": {
-                "additionalProperties": false,
-                "anyOf": [
-                    {"required": ["AccountTypeId", "PolicyId"]},
-                    {"required": ["AccountTypeName", "PolicyId"]},
-                ],
-                "properties": {
-                    "AccountTypeId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "AccountTypeName": {"type": "string"},
-                    "PolicyId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                },
-                "type": "object",
-            },
-            "Alias": {
-                "properties": {
-                    "Alias": {
-                        "properties": {
-                            "Status": {
-                                "enum": [
-                                    "The company alias provided is available",
-                                    "The company alias provided is already in use by another customer and cannot be used",
-                                ],
-                                "example": "The company alias provided is available",
-                                "type": "string",
-                            }
-                        },
-                        "type": "object",
-                    }
-                },
-                "type": "object",
-            },
-            "AliasInUse": {
-                "properties": {
-                    "Alias": {
-                        "properties": {
-                            "Status": {
-                                "enum": [
-                                    "The company alias provided is available",
-                                    "The company alias provided is already in use by another customer and cannot be used",
-                                ],
-                                "example": "The company alias provided is already in use by another customer and cannot be used",
-                                "type": "string",
-                            }
-                        },
-                        "type": "object",
-                    }
-                },
-                "type": "object",
-            },
-            "ApiRole": {
-                "description": "Stax role assigned to an API Token.",
-                "enum": ["api_admin", "api_user", "api_readonly"],
-                "type": "string",
-            },
-            "AwsAccessRole": {
-                "description": "AWS access roles enabled for an account type.",
-                "enum": ["admin", "developer", "readonly"],
-                "type": "string",
-            },
-            "AwsRegion": {
-                "description": "AWS Region",
-                "enum": [
-                    "ap-northeast-1",
-                    "ap-northeast-2",
-                    "ap-south-1",
-                    "ap-southeast-1",
-                    "ap-southeast-2",
-                    "ca-central-1",
-                    "eu-central-1",
-                    "eu-north-1",
-                    "eu-west-1",
-                    "eu-west-2",
-                    "eu-west-3",
-                    "sa-east-1",
-                    "us-east-1",
-                    "us-east-2",
-                    "us-west-1",
-                    "us-west-2",
-                ],
-                "type": "string",
-            },
-            "BaseEvent": {
-                "properties": {"DetailType": {"type": "string"}},
-                "type": "object",
-            },
-            "BaseEventDetail": {
-                "properties": {
-                    "Message": {"type": "string"},
-                    "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                    "OperationStatus": {
-                        "$ref": "#\/components\/schemas\/OperationStatus"
-                    },
-                    "Severity": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "BaseTask": {
-                "properties": {
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Status": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "CidrExclusion": {
-                "additionalProperties": false,
-                "properties": {
-                    "Cidr": {
-                        "description": "CIDR Range in quad dot notation.",
-                        "example": "10.128.0.0\/19",
-                        "type": "string",
-                    },
-                    "CreatedBy": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Description": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "Longer description of what the CIDR Exclusion is used for.",
-                                "example": "datacenter exclusion",
-                                "maxLength": 512,
-                                "minLength": 0,
-                                "type": "string",
-                            },
-                        ]
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the CIDR Exclusion.",
-                        "example": "non-prod",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "NetworkingHubId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "Status": {
-                        "description": "The status of the CIRD Exclusion.",
-                        "enum": ["ACTIVE", "DELETED", "CREATE_FAILED", "DELETE_FAILED"],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["Name", "Cidr"],
-                "type": "object",
-            },
-            "CidrRange": {
-                "properties": {
-                    "Cidr": {
-                        "description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
-                        "example": "10.128.0.0\/23",
-                        "type": "string",
-                    },
-                    "CreatedBy": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "DefaultCidrRange": {
-                        "description": "Boolean value declaring if the range is the default CIDR Range",
-                        "example": false,
-                        "type": "boolean",
-                    },
-                    "Description": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "Longer description of what the CIDR Range is used for.",
-                                "example": "datacenter ranges",
-                                "maxLength": 512,
-                                "minLength": 0,
-                                "type": "string",
-                            },
-                        ]
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "LastAllocationTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the CIDR Range.",
-                        "example": "non-prod",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "NetworkingHubId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Status": {
-                        "description": "The status of the CIDR Range.",
-                        "enum": ["ACTIVE", "DELETED", "CREATE_FAILED", "DELETE_FAILED"],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["Name", "Cidr"],
-                "type": "object",
-            },
-            "Config": {
-                "properties": {
-                    "API": {
-                        "properties": {
-                            "endpoints": {
-                                "items": {
-                                    "$ref": "#\/components\/schemas\/ConfigEndpoint"
-                                },
-                                "type": "array",
-                            }
-                        },
-                        "type": "object",
-                    },
-                    "Analytics": {
-                        "properties": {"disable": {"type": "boolean"}},
-                        "type": "object",
-                    },
-                    "ApiAuth": {
-                        "properties": {
-                            "identityPoolId": {"type": "string"},
-                            "mandatorySignIn": {"type": "boolean"},
-                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                            "userPoolId": {"type": "string"},
-                            "userPoolWebClientId": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "AppSync": {
-                        "properties": {
-                            "analytics": {
-                                "properties": {
-                                    "endpoint": {"type": "string"},
-                                    "region": {
-                                        "$ref": "#\/components\/schemas\/AwsRegion"
-                                    },
-                                },
-                                "type": "object",
-                            },
-                            "core": {
-                                "properties": {
-                                    "endpoint": {"type": "string"},
-                                    "region": {
-                                        "$ref": "#\/components\/schemas\/AwsRegion"
-                                    },
-                                },
-                                "type": "object",
-                            },
-                            "graphqlEndpoint": {"type": "string"},
-                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                        },
-                        "type": "object",
-                    },
-                    "Auth": {
-                        "properties": {
-                            "identityPoolId": {"type": "string"},
-                            "mandatorySignIn": {"type": "boolean"},
-                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                            "userPoolId": {"type": "string"},
-                            "userPoolWebClientId": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "Juma": {
-                        "properties": {
-                            "controlplaneRegion": {"type": "string"},
-                            "domainName": {"type": "string"},
-                            "fullDomainName": {"type": "string"},
-                            "masterAccountId": {"type": "string"},
-                            "rootOrgId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "stage": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "JumaAuth": {
-                        "properties": {
-                            "identityPoolId": {"type": "string"},
-                            "mandatorySignIn": {"type": "boolean"},
-                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                            "userPoolId": {"type": "string"},
-                            "userPoolWebClientId": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "Pingdom": {
-                        "properties": {"key": {"nullable": true, "type": "string"}},
-                        "type": "object",
-                    },
-                    "SNS": {
-                        "properties": {
-                            "event": {"type": "string"},
-                            "notify": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "Sentry": {
-                        "properties": {
-                            "dsn": {"type": "string"},
-                            "projectName": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "Storage": {
-                        "properties": {
-                            "bucket": {"type": "string"},
-                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                        },
-                        "type": "object",
-                    },
-                    "Zone": {
-                        "properties": {"key": {"type": "string"}},
-                        "type": "object",
-                    },
-                },
-                "required": ["Auth", "API"],
-                "type": "object",
-            },
-            "ConfigEndpoint": {
-                "properties": {
-                    "endpoint": {"type": "string"},
-                    "name": {"type": "string"},
-                    "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                },
-                "type": "object",
-            },
-            "CreateCatalogueDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "TraceId": {"type": "string"},
-                    "WorkloadCatalogueItem": {
-                        "properties": {
-                            "CatalogueId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "Description": {
-                                "description": "Description of the Workload.",
-                                "example": "A Workload to build a VPC in my org",
-                                "maxLength": 1024,
-                                "type": "string",
-                            },
-                            "ManifestURL": {
-                                "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-                                "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-                                "type": "string",
-                            },
-                            "Name": {
-                                "description": "Name of the Workload Catalogue Item to create.",
-                                "example": "my-directory-service",
-                                "maxLength": 64,
-                                "minLength": 2,
-                                "type": "string",
-                            },
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "Public": {
-                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-                                "example": false,
-                                "type": "boolean",
-                            },
-                            "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                            "Version": {
-                                "example": "0.01",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                        },
-                        "type": "object",
-                    },
-                },
-                "type": "object",
-            },
-            "CreateCatalogueEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Detail": {"$ref": "#\/components\/schemas\/CreateCatalogueDetail"},
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "TraceId": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "CreatePolicyDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "Policy": {
-                        "properties": {
-                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "Description": {
-                                "description": "Description of the Policy.",
-                                "example": "A service control policy that denies access to all.",
-                                "maxLength": 1024,
-                                "minLength": 3,
-                                "type": "string",
-                            },
-                            "Name": {
-                                "description": "Name of the Policy.",
-                                "example": "DenyAll",
-                                "maxLength": 128,
-                                "minLength": 3,
-                                "type": "string",
-                            },
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OrgId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "Policy": {"type": "string"},
-                            "PolicyId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TraceId": {"type": "string"},
-                        },
-                        "type": "object",
-                    }
-                },
-                "type": "object",
-            },
-            "CreatePolicyEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "Detail": {"$ref": "#\/components\/schemas\/CreatePolicyDetail"},
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "type": "object",
-            },
-            "CreateVersionDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "TraceId": {"type": "string"},
-                    "WorkloadCatalogueItem": {
-                        "properties": {
-                            "CatalogueId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "Description": {
-                                "description": "Description of the Workload.",
-                                "example": "A Workload to build a VPC in my org",
-                                "maxLength": 1024,
-                                "type": "string",
-                            },
-                            "ManifestBody": {
-                                "description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
-                                "example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
-                                "type": "string",
-                            },
-                            "ManifestURL": {
-                                "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-                                "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-                                "type": "string",
-                            },
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
-                            "Public": {
-                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-                                "example": false,
-                                "type": "boolean",
-                            },
-                            "Version": {
-                                "example": "0.01",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                        },
-                        "type": "object",
-                    },
-                },
-                "type": "object",
-            },
-            "CreateVersionEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Detail": {"$ref": "#\/components\/schemas\/CreateVersionDetail"},
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "TraceId": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "CreateWorkloadDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "Workload": {
-                        "properties": {
-                            "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "CatalogueId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "CatalogueVersionId": {
-                                "$ref": "#\/components\/schemas\/uuidv4"
-                            },
-                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "Name": {
-                                "description": "The Workload name.",
-                                "example": "my-workload-is-cool",
-                                "maxLength": 64,
-                                "minLength": 2,
-                                "type": "string",
-                            },
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OrgId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/uuidv4"
-                            },
-                            "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
-                            "Region": {
-                                "description": "AWS Region the workload will be launched in",
-                                "example": "us-east-1",
-                                "maxLength": 32,
-                                "type": "string",
-                            },
-                            "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                            "TaskId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "TraceId": {"type": "string"},
-                            "WorkloadId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                        },
-                        "type": "object",
-                    }
-                },
-                "type": "object",
-            },
-            "CreateWorkloadEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "Detail": {"$ref": "#\/components\/schemas\/CreateWorkloadDetail"},
-                    "WorkloadId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "type": "object",
-            },
-            "Customer": {
-                "properties": {
-                    "CognitoUserId": {
-                        "description": "Cognito User unique identifier.",
-                        "example": "my-user-id",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Email": {
-                        "description": "Email address of the User.",
-                        "example": "stax.user@example.com",
-                        "format": "email",
-                        "maxLength": 128,
-                        "minLength": 6,
-                        "type": "string",
-                    },
-                    "FactoryVersion": {"$ref": "#\/components\/schemas\/GitHash"},
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Account.",
-                        "example": "My Business",
-                        "maxLength": 64,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "Status": {
-                        "description": "Status of the Customer.",
-                        "enum": [
-                            "PROSPECT",
-                            "NEW",
-                            "INITIALIZING",
-                            "ACTIVE",
-                            "SUSPENDED",
-                        ],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "SupportPlan": {
-                        "description": "Stax Support Plan allocated to the Customer.",
-                        "enum": ["BASIC", "BUSINESS", "ENTERPRISE"],
-                        "example": "BUSINESS",
-                        "type": "string",
-                    },
-                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "required": ["Name", "Email"],
-                "type": "object",
-            },
-            "DNSResolver": {
-                "additionalProperties": false,
-                "properties": {
-                    "CreatedBy": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "InboundIpAddresses": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The IP Addresses attached to the Inbound DNS Resolver.",
-                                "example": ["192.168.0.1", "192.168.0.2"],
-                                "items": {"type": "string"},
-                                "type": "array",
-                            },
-                        ]
-                    },
-                    "Interfaces": {
-                        "description": "The number of ENIs to attach to the DNS Resolvers.",
-                        "example": 2,
-                        "type": "integer",
-                    },
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Stax DNS Resolvers.",
-                        "example": "dns",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "NetworkingHubId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "OutboundIpAddresses": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The IP Addresses attached to the Outbound DNS Resolver.",
-                                "example": ["192.168.0.1", "192.168.0.2"],
-                                "items": {"type": "string"},
-                                "type": "array",
-                            },
-                        ]
-                    },
-                    "Status": {
-                        "description": "The status of the Stax DNS Resolvers.",
-                        "enum": [
-                            "ACTIVE",
-                            "CREATE_IN_PROGRESS",
-                            "CREATE_FAILED",
-                            "DELETE_IN_PROGRESS",
-                            "DELETED",
-                            "DELETE_FAILED",
-                            "UPDATE_IN_PROGRESS",
-                        ],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "UserTaskId": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                },
-                "required": ["Name", "NetworkingHubId", "Interfaces"],
-                "type": "object",
-            },
-            "DNSRule": {
-                "additionalProperties": false,
-                "properties": {
-                    "AwsRuleId": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The AWS Route53 Resolver Rule Id.",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                        ]
-                    },
-                    "CreatedBy": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "DnsResolverId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "DomainName": {
-                        "description": "Domain name to forward DNS queries for.",
-                        "example": "test.local",
-                        "maxLength": 128,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "ForwarderIpAddresses": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The IP Addresses to forward DNS queries to.",
-                                "example": ["192.168.0.1", "192.168.0.2"],
-                                "items": {"type": "string"},
-                                "type": "array",
-                            },
-                        ]
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of Stax DNS Rule.",
-                        "example": "on-premises",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Status": {
-                        "description": "The status of the Stax DNS Rule.",
-                        "enum": [
-                            "ACTIVE",
-                            "CREATE_IN_PROGRESS",
-                            "CREATE_FAILED",
-                            "DELETE_IN_PROGRESS",
-                            "DELETED",
-                            "DELETE_FAILED",
-                            "UPDATE_IN_PROGRESS",
-                        ],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "UserTaskId": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                },
-                "required": ["Name", "DomainName", "DnsResolverId"],
-                "type": "object",
-            },
-            "DeleteCatalogueDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "AdditionalMetaData": {
-                        "properties": {
-                            "CatalogueVersionId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "CreatedTS": {
-                                "description": "Created timestamp.",
-                                "example": "2018-10-11T01:05:45.000Z",
-                                "format": "date-time",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                            "Description": {
-                                "description": "Description of the Workload.",
-                                "example": "A Workload to build a VPC in my org",
-                                "maxLength": 1024,
-                                "type": "string",
-                            },
-                            "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "ModifiedTS": {
-                                "description": "Modified timestamp.",
-                                "example": "2018-10-11T01:05:45.000Z",
-                                "format": "date-time",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                            "Name": {
-                                "description": "Name of the Workload Catalogue Item to create.",
-                                "example": "my-directory-service",
-                                "maxLength": 64,
-                                "minLength": 2,
-                                "type": "string",
-                            },
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/uuidv4"
-                            },
-                            "Protection": {
-                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-                                "example": false,
-                                "type": "boolean",
-                            },
-                            "Public": {
-                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-                                "example": false,
-                                "type": "boolean",
-                            },
-                            "Status": {
-                                "description": "Status of the Workload.",
-                                "enum": [
-                                    "NEW",
-                                    "UPLOADING",
-                                    "VALIDATING",
-                                    "ACTIVE",
-                                    "DELETED",
-                                    "FAILED",
-                                ],
-                                "example": "NEW",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                            "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        },
-                        "type": "object",
-                    },
-                    "TraceId": {"type": "string"},
-                    "WorkloadCatalogueItem": {
-                        "$ref": "#\/components\/schemas\/Operation"
-                    },
-                },
-                "type": "object",
-            },
-            "DeleteCatalogueEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Detail": {"$ref": "#\/components\/schemas\/DeleteCatalogueDetail"},
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "TraceId": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "DeletePolicyDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "Policy": {
-                        "properties": {
-                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OrgId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "PolicyId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TraceId": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "type": "object",
-            },
-            "DeletePolicyEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "Detail": {"$ref": "#\/components\/schemas\/DeletePolicyDetail"},
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "type": "object",
-            },
-            "DeleteVersionDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "AdditionalMetaData": {
-                        "properties": {
-                            "CatalogueId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "CreatedTS": {
-                                "description": "Created timestamp.",
-                                "example": "2018-10-11T01:05:45.000Z",
-                                "format": "date-time",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                            "Description": {
-                                "description": "Description of the Workload.",
-                                "example": "A Workload to build a VPC in my org",
-                                "maxLength": 1024,
-                                "type": "string",
-                            },
-                            "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "ManifestURL": {
-                                "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-                                "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-                                "type": "string",
-                            },
-                            "ModifiedTS": {
-                                "description": "Modified timestamp.",
-                                "example": "2018-10-11T01:05:45.000Z",
-                                "format": "date-time",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                            "Outputs": {
-                                "items": {"example": "bread", "type": "string"},
-                                "nullable": true,
-                                "readOnly": true,
-                                "type": "array",
-                            },
-                            "Public": {
-                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-                                "example": false,
-                                "type": "boolean",
-                            },
-                            "Status": {
-                                "description": "Status of the Workload.",
-                                "enum": [
-                                    "NEW",
-                                    "UPLOADING",
-                                    "VALIDATING",
-                                    "ACTIVE",
-                                    "DELETED",
-                                    "FAILED",
-                                ],
-                                "example": "NEW",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                            "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "WorkloadCatalogueName": {
-                                "description": "Name of the Workload Catalogue Item to create.",
-                                "example": "my-directory-service",
-                                "maxLength": 64,
-                                "minLength": 2,
-                                "type": "string",
-                            },
-                            "WorkloadVersion": {
-                                "example": "0.01",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                        },
-                        "type": "object",
-                    },
-                    "TraceId": {"type": "string"},
-                    "WorkloadCatalogueVersion": {
-                        "$ref": "#\/components\/schemas\/ro-uuidv4"
-                    },
-                },
-                "type": "object",
-            },
-            "DeleteVersionEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Detail": {"$ref": "#\/components\/schemas\/DeleteVersionDetail"},
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "TraceId": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "DeleteWorkloadDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "Workload": {
-                        "properties": {
-                            "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "CatalogueVersionId": {
-                                "$ref": "#\/components\/schemas\/uuidv4"
-                            },
-                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "Name": {
-                                "description": "The Workload name.",
-                                "example": "my-workload-is-cool",
-                                "maxLength": 64,
-                                "minLength": 2,
-                                "type": "string",
-                            },
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OrgId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/uuidv4"
-                            },
-                            "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
-                            "Region": {
-                                "description": "AWS Region the workload will be launched in",
-                                "example": "us-east-1",
-                                "maxLength": 32,
-                                "type": "string",
-                            },
-                            "TaskId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "TraceId": {"type": "string"},
-                            "WorkloadId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        },
-                        "type": "object",
-                    }
-                },
-                "type": "object",
-            },
-            "DeleteWorkloadEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "Detail": {"$ref": "#\/components\/schemas\/DeleteWorkloadDetail"}
-                },
-                "type": "object",
-            },
-            "Error": {
-                "properties": {
-                    "Cause": {"type": "string"},
-                    "Error": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "GetTasks": {
-                "properties": {"Tasks": {"$ref": "#\/components\/schemas\/Task"}},
-                "type": "object",
-            },
-            "GitHash": {
-                "example": "f8cf81b",
-                "maxLength": 7,
-                "minLength": 7,
-                "readOnly": true,
-                "type": "string",
-            },
-            "Group": {
-                "properties": {
-                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Group.",
-                        "example": "DevOps",
-                        "maxLength": 128,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Status": {
-                        "description": "Status of the Group.",
-                        "enum": ["ACTIVE", "DELETED"],
-                        "example": "ACTIVE",
-                        "type": "string",
-                    },
-                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Users": {
-                        "description": "Array of IDs of Users belonging to the Group.",
-                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        "type": "array",
-                    },
-                },
-                "required": ["Id", "Name"],
-                "type": "object",
-            },
-            "IdamUser": {
-                "properties": {"id": {"$ref": "#\/components\/schemas\/uuidv4"}},
-                "required": ["id"],
-                "type": "object",
-            },
-            "NetworkingHub": {
-                "additionalProperties": false,
-                "properties": {
-                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "Asn": {
-                        "description": "A private Autonomous System Number (ASN) for the Amazon side of a BGP session",
-                        "example": 64512,
-                        "type": "integer",
-                    },
-                    "CreatedBy": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Description": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "Longer description of what the Stax Networking Hub is used for.",
-                                "example": "my-hub",
-                                "maxLength": 512,
-                                "minLength": 0,
-                                "type": "string",
-                            },
-                        ]
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "InterfaceEndpoints": {
-                        "items": {"$ref": "#\/components\/schemas\/interface-endpoint"},
-                        "type": "array",
-                    },
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of Stax Networking Hub.",
-                        "example": "non-prod",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "PhzSuffix": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
-                                "example": "my-domain.cloud",
-                                "type": "string",
-                            },
-                        ]
-                    },
-                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                    "Status": {
-                        "description": "The status of the Stax Networking Hub.",
-                        "enum": [
-                            "ACTIVE",
-                            "CREATE_IN_PROGRESS",
-                            "CREATE_FAILED",
-                            "DELETE_IN_PROGRESS",
-                            "DELETED",
-                            "DELETE_FAILED",
-                            "UPDATE_IN_PROGRESS",
-                        ],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "UserTaskId": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                },
-                "required": ["Name", "AccountId", "Region"],
-                "type": "object",
-            },
-            "Operation": {
-                "enum": [
-                    "CREATE",
-                    "READ",
-                    "UPDATE",
-                    "DELETE",
-                    "accounts:CreateAccount",
-                    "accounts:CreateAccountType",
-                    "accounts:DiscoverAccounts",
-                    "accounts:DeleteAccountType",
-                    "accounts:ReadAccountTypes",
-                    "accounts:ReadAccounts",
-                    "accounts:UpdateAccount",
-                    "accounts:UpdateAccountType",
-                    "accounts:UpdateAccountTypeAccess",
-                    "accounts:UpdateAccountTypeMembers",
-                    "accounts:UpdatePolicies",
-                    "organisations:AttachPolicy",
-                    "organisations:CreatePolicy",
-                    "organisations:DeletePolicy",
-                    "organisations:DetachPolicy",
-                    "organisations:ReadPolicies",
-                    "organisations:UpdatePolicy",
-                    "teams:CreateApiToken",
-                    "teams:CreateGroup",
-                    "teams:CreateUser",
-                    "teams:DeleteApiToken",
-                    "teams:DeleteGroup",
-                    "teams:DeleteUser",
-                    "teams:ReadApiTokens",
-                    "teams:ReadGroups",
-                    "teams:ReadUsers",
-                    "teams:UpdateApiToken",
-                    "teams:UpdateGroup",
-                    "teams:UpdateGroupMembers",
-                    "teams:UpdateUser",
-                    "teams:UpdateUserPassword",
-                    "workloads:CreateCatalogueItem",
-                    "workloads:CreateCatalogueVersion",
-                    "workloads:CreateWorkload",
-                    "workloads:DeleteCatalogueItem",
-                    "workloads:DeleteCatalogueVersion",
-                    "workloads:DeleteWorkload",
-                    "workloads:ReadWorkloadCatalogueItems",
-                    "workloads:ReadWorkloads",
-                    "workloads:UpdateWorkload",
-                    "networking:CreateHub",
-                    "networking:UpdateHub",
-                    "networking:DeleteHub",
-                    "networking:CreateVpc",
-                    "networking:UpdateVpc",
-                    "networking:DeleteVpc",
-                    "networking:CreateDnsResolver",
-                    "networking:UpdateDnsResolver",
-                    "networking:DeleteDnsResolver",
-                    "networking:CreateDnsRule",
-                    "networking:UpdateDnsRule",
-                    "networking:DeleteDnsRule",
-                ],
-                "type": "string",
-            },
-            "OperationStatus": {
-                "enum": [
-                    "STARTED",
-                    "RUNNING",
-                    "SUCCEEDED",
-                    "FAILED",
-                    "TIMED_OUT",
-                    "ABORTED",
-                ],
-                "type": "string",
-            },
-            "Organisation": {
-                "properties": {
-                    "Alias": {
-                        "description": "Alias for your Organisation. This alias will be used in the URL of your Stax Identity Broker.",
-                        "example": "my-stax-org",
-                        "maxLength": 64,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "AllowedDomains": {
-                        "description": "Allowed email domains for the Organisation, this limits who can be invited to your Team.",
-                        "example": "@example.com,@stax.io",
-                        "maxLength": 64,
-                        "minLength": 3,
-                        "nullable": true,
-                        "type": "string",
-                    },
-                    "AttachedPolicies": {
-                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        "readOnly": true,
-                        "type": "array",
-                    },
-                    "AwsAccountEmailTemplate": {
-                        "description": "AWS Accounts will be registered with email addresses fitting this pattern. Please ensure these email addresses are secured, as they can be used for Root Credential recovery.",
-                        "example": "stax.user+${Stax::AccountId}@example.com",
-                        "maxLength": 64,
-                        "minLength": 3,
-                        "nullable": true,
-                        "type": "string",
-                    },
-                    "AwsPartnerSupport": {
-                        "description": "AWS Partner Led Support - if you have partner led support then Stax Support will open AWS Support cases on your behalf.",
-                        "type": "boolean",
-                    },
-                    "AwsSupportType": {
-                        "description": "Default AWS Support level set on Accounts in your Organisation.",
-                        "enum": ["BASIC", "DEVELOPER", "BUSINESS", "ENTERPRISE"],
-                        "example": "ENTERPRISE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "CreatedBy": {
-                        "anyOf": [
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            {"nullable": true},
-                        ]
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ExternalStaxId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Organisation",
-                        "example": "default",
-                        "maxLength": 64,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                    "SpotlightSsoURL": {"readOnly": true, "type": "string"},
-                    "Status": {
-                        "description": "Status of the Organisation.",
-                        "enum": ["NEW", "INITIALIZING", "ACTIVE", "SUSPENDED"],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "type": "object",
-            },
-            "Pagination": {
-                "description": "Pagination metadata. Present when limit and offset parameters are supplied.",
-                "properties": {
-                    "NextOffset": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "Offset value to provide to retrieve the next set of items. Null when there are no more pages to fetch.",
-                                "example": 20,
-                                "type": "number",
-                            },
-                        ]
-                    },
-                    "PrevOffset": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "Offset value to provide to retrieve the previous set of items. Null when the first page is returned.",
-                                "example": null,
-                                "type": "number",
-                            },
-                        ]
-                    },
-                    "Total": {
-                        "description": "Total number of items in the full pagination set after filters are applied.",
-                        "example": 100,
-                        "type": "number",
-                    },
-                },
-                "required": ["Total", "NextOffset", "PrevOffset"],
-                "type": "object",
-            },
-            "Parameter": {
-                "example": {"Key": "Bread", "Value": "Croissant"},
-                "nullable": true,
-                "properties": {
-                    "Key": {"maxLength": 255, "minLength": 1, "type": "string"},
-                    "Value": {
-                        "oneOf": [
-                            {"maxLength": 4096, "minLength": 1, "type": "string"},
-                            {"type": "integer"},
-                        ]
-                    },
-                },
-                "type": "object",
-            },
-            "Policy": {
-                "properties": {
-                    "AttachableTo": {
-                        "description": "Whether a policy is org only or account type only, or both",
-                        "enum": ["ORG", "ACCOUNT_TYPE", "ANY"],
-                        "example": "ANY",
-                        "readOnly": false,
-                        "type": "string",
-                    },
-                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Description": {
-                        "description": "Description of the Policy.",
-                        "example": "A service control policy that denies access to all.",
-                        "maxLength": 1024,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Mandatory": {
-                        "description": "Boolean value declaring if the policy is mandatory or not.",
-                        "example": false,
-                        "type": "boolean",
-                    },
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Policy.",
-                        "example": "DenyAll",
-                        "maxLength": 128,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Policy": {"type": "string"},
-                    "Public": {
-                        "description": "Boolean value declaring if the policy is public or private.",
-                        "example": false,
-                        "type": "boolean",
-                    },
-                    "Status": {
-                        "description": "Status of the policy.",
-                        "enum": ["ACTIVE", "DELETED", "FAILED"],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                },
-                "type": "object",
-            },
-            "Resource": {
-                "properties": {
-                    "ResourceId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ResourceType": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "Role": {
-                "description": "Stax role assigned to user.",
-                "enum": [
-                    "customer_root",
-                    "customer_admin",
-                    "customer_user",
-                    "customer_readonly",
-                ],
-                "example": "customer_admin",
-                "type": "string",
-            },
-            "StaxEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "Details": {"$ref": "#\/components\/schemas\/TaskEventDetail"}
-                },
-            },
-            "Tags": {
-                "anyOf": [
-                    {
-                        "additionalProperties": {"type": "string"},
-                        "maxProperties": 100,
-                        "minProperties": 1,
-                        "type": "object",
-                    },
-                    {"nullable": true},
-                ],
-                "example": {"CostCode": "12345"},
-            },
-            "Task": {"$ref": "#\/components\/schemas\/WorkloadTask"},
-            "TaskEventDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {"TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"}},
-            },
-            "TraceEventDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {"TraceId": {"type": "string"}},
-            },
-            "UpdateCatalogueDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "TraceId": {"type": "string"},
-                    "WorkloadCatalogueItem": {
-                        "properties": {
-                            "CatalogueId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "Description": {
-                                "description": "Description of the Workload.",
-                                "example": "A Workload to build a VPC in my org",
-                                "maxLength": 1024,
-                                "type": "string",
-                            },
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "Public": {
-                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-                                "example": false,
-                                "type": "boolean",
-                            },
-                            "Version": {
-                                "example": "0.01",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                        },
-                        "type": "object",
-                    },
-                },
-                "type": "object",
-            },
-            "UpdateCatalogueEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Detail": {"$ref": "#\/components\/schemas\/UpdateCatalogueDetail"},
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "TraceId": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "UpdatePolicyDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "Policy": {
-                        "properties": {
-                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "Name": {
-                                "description": "Name of the Policy.",
-                                "example": "DenyAll",
-                                "maxLength": 128,
-                                "minLength": 3,
-                                "type": "string",
-                            },
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OrgId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/ro-uuidv4"
-                            },
-                            "PolicyId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TraceId": {"type": "string"},
-                        },
-                        "type": "object",
-                    }
-                },
-                "type": "object",
-            },
-            "UpdatePolicyEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "Detail": {"$ref": "#\/components\/schemas\/UpdatePolicyDetail"},
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "type": "object",
-            },
-            "UpdateWorkloadDetail": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
-                "properties": {
-                    "Workload": {
-                        "properties": {
-                            "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "CatalogueVersionId": {
-                                "$ref": "#\/components\/schemas\/uuidv4"
-                            },
-                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "Name": {
-                                "description": "The Workload name.",
-                                "example": "my-workload-is-cool",
-                                "maxLength": 64,
-                                "minLength": 2,
-                                "type": "string",
-                            },
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OrgId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "OrganisationId": {
-                                "$ref": "#\/components\/schemas\/uuidv4"
-                            },
-                            "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
-                            "Region": {
-                                "description": "AWS Region the workload will be launched in",
-                                "example": "us-east-1",
-                                "maxLength": 32,
-                                "type": "string",
-                            },
-                            "TaskId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                            "TraceId": {"type": "string"},
-                            "WorkloadId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                        },
-                        "type": "object",
-                    }
-                },
-                "type": "object",
-            },
-            "UpdateWorkloadEvent": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
-                "properties": {
-                    "Detail": {"$ref": "#\/components\/schemas\/UpdateWorkloadDetail"},
-                    "WorkloadId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "type": "object",
-            },
-            "User": {
-                "properties": {
-                    "AuthOrigin": {
-                        "example": "idam",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "CreatedBy": {
-                        "oneOf": [
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            {"nullable": true},
-                        ]
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "CustomerId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "Description": {
-                        "example": "Marketing User",
-                        "nullable": true,
-                        "type": "string",
-                    },
-                    "Email": {
-                        "description": "Email address of User.",
-                        "example": "stax.user@example.com",
-                        "format": "email",
-                        "maxLength": 128,
-                        "minLength": 6,
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "FirstName": {
-                        "oneOf": [
-                            {
-                                "description": "Given Name of the User.",
-                                "example": "John",
-                                "maxLength": 128,
-                                "minLength": 0,
-                                "type": "string",
-                            },
-                            {"nullable": true},
-                        ]
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "LastName": {
-                        "oneOf": [
-                            {
-                                "description": "Family Name of the User.",
-                                "example": "Doe",
-                                "maxLength": 128,
-                                "minLength": 0,
-                                "type": "string",
-                            },
-                            {"nullable": true},
-                        ]
-                    },
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Concatenation of first and last name. Defaults to email address if neither are present.",
-                        "example": "John Doe",
-                        "maxLength": 128,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "PhoneNumber": {
-                        "description": "Phone number of User in E.164 format.",
-                        "example": "+61491570006",
-                        "nullable": true,
-                        "pattern": "^\\+[1-9]\\d{4,14}$",
-                        "type": "string",
-                    },
-                    "Role": {"$ref": "#\/components\/schemas\/Role"},
-                    "Status": {
-                        "description": "Status of the User.",
-                        "enum": ["ACTIVE", "DISABLED", "DELETED", "INVITED", "NEW"],
-                        "example": "ACTIVE",
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "required": ["Id", "Email", "Name", "OrganisationId"],
-                "type": "object",
-            },
-            "UserGroupMemberMap": {
-                "additionalProperties": false,
-                "properties": {
-                    "GroupId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "UserId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                },
-                "type": "object",
-            },
-            "UserTask": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseTask"}],
-                "properties": {
-                    "Users": {
-                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "VPC": {
-                "additionalProperties": false,
-                "properties": {
-                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "AwsVpcId": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The AWS VPC ID.",
-                                "readOnly": true,
-                                "type": "string",
-                            },
-                        ]
-                    },
-                    "Cidr": {
-                        "description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
-                        "example": "10.128.0.0\/23",
-                        "type": "string",
-                    },
-                    "CidrRangeId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "CreateIgw": {
-                        "description": "Boolean value declaring if Internet Gateway is enabled",
-                        "example": true,
-                        "type": "boolean",
-                    },
-                    "CreateNat": {
-                        "description": "Boolean value declaring if NAT Gateways is enabled",
-                        "example": true,
-                        "type": "boolean",
-                    },
-                    "CreatedBy": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Description": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "Longer description of what the Stax VPC is used for.",
-                                "example": "VPC for my particular application",
-                                "maxLength": 2048,
-                                "minLength": 0,
-                                "type": "string",
-                            },
-                        ]
-                    },
-                    "GatewayEndpoints": {
-                        "items": {"$ref": "#\/components\/schemas\/gateway-endpoint"},
-                        "type": "array",
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of Stax VPC",
-                        "example": "non-prod",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "NetworkingHubId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "PhzId": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The Route53 Private Hosted Zone Id for the VPC",
-                                "example": "PHZAAEXAMPLE",
-                                "type": "string",
-                            },
-                        ]
-                    },
-                    "PhzPrefix": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
-                                "example": "dev",
-                                "type": "string",
-                            },
-                        ]
-                    },
-                    "RedundantNat": {
-                        "description": "Boolean value declaring if redundant NAT Gateways will be created",
-                        "example": false,
-                        "type": "boolean",
-                    },
-                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                    "Size": {
-                        "description": "Size of the VPC.",
-                        "enum": ["SMALL", "MEDIUM", "LARGE"],
-                        "example": "SMALL",
-                        "type": "string",
-                    },
-                    "Status": {
-                        "description": "The status of the Stax VPC.",
-                        "enum": [
-                            "ACTIVE",
-                            "CREATE_IN_PROGRESS",
-                            "CREATE_FAILED",
-                            "DELETE_IN_PROGRESS",
-                            "DELETED",
-                            "DELETE_FAILED",
-                            "UPDATE_IN_PROGRESS",
-                        ],
-                        "example": "ACTIVE",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "Type": {
-                        "description": "Type of VPC. The Type determines what Route Tables are attached to the VPC",
-                        "enum": ["FLAT", "ISOLATED", "SHAREDSERVICES", "TRANSIT"],
-                        "example": "FLAT",
-                        "type": "string",
-                    },
-                    "UserTaskId": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        ]
-                    },
-                    "Zone": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "All 'Flat' VPCs in the same Zone can communicate to each other.",
-                                "example": "non-prod",
-                                "maxLength": 32,
-                                "minLength": 2,
-                                "type": "string",
-                            },
-                        ]
-                    },
-                },
-                "required": ["Name", "AccountId", "Region"],
-                "type": "object",
-            },
-            "Workload": {
-                "properties": {
-                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "CatalogueId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "CatalogueVersionId": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {"$ref": "#\/components\/schemas\/uuidv4"},
-                        ]
-                    },
-                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "The Workload name.",
-                        "example": "my-workload-is-cool",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
-                    "Protection": {
-                        "description": "Boolean value declaring if the Workload is protected from deletion",
-                        "example": false,
-                        "type": "boolean",
-                    },
-                    "Region": {
-                        "description": "AWS Region the workload will be launched in",
-                        "example": "us-east-1",
-                        "maxLength": 32,
-                        "type": "string",
-                    },
-                    "Status": {
-                        "description": "Status of the Workload.",
-                        "enum": [
-                            "NEW",
-                            "INITIALIZING",
-                            "ACTIVE",
-                            "CREATE_FAILED",
-                            "DELETE_IN_PROGRESS",
-                            "DELETED",
-                            "DELETE_FAILED",
-                            "UPDATE_IN_PROGRESS",
-                            "UPDATE_FAILED",
-                            "UPDATE_COMPLETE",
-                        ],
-                        "example": "NEW",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                },
-                "required": ["Name", "CatalogueId", "AccountId", "Region"],
-                "type": "object",
-            },
-            "WorkloadCatalogue": {
-                "properties": {
-                    "CatalogueVersionId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Description": {
-                        "description": "Description of the Workload.",
-                        "example": "A Workload to build a VPC in my org",
-                        "maxLength": 1024,
-                        "type": "string",
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Workload Catalogue Item to create.",
-                        "example": "my-directory-service",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "Protection": {
-                        "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-                        "example": false,
-                        "type": "boolean",
-                    },
-                    "Public": {
-                        "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-                        "example": false,
-                        "type": "boolean",
-                    },
-                    "Status": {
-                        "description": "Status of the Workload.",
-                        "enum": [
-                            "NEW",
-                            "UPLOADING",
-                            "VALIDATING",
-                            "ACTIVE",
-                            "DELETED",
-                            "FAILED",
-                        ],
-                        "example": "NEW",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Versions": {
-                        "items": {
-                            "$ref": "#\/components\/schemas\/WorkloadCatalogueVersion"
-                        },
-                        "readOnly": true,
-                        "type": "array",
-                    },
-                },
-                "required": ["Id", "Versions"],
-            },
-            "WorkloadCatalogueVersion": {
-                "properties": {
-                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "CreatedTS": {
-                        "description": "Created timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Description": {
-                        "description": "Description of the Workload.",
-                        "example": "A Workload to build a VPC in my org",
-                        "maxLength": 1024,
-                        "type": "string",
-                    },
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "ManifestURL": {
-                        "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-                        "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-                        "type": "string",
-                    },
-                    "ModifiedTS": {
-                        "description": "Modified timestamp.",
-                        "example": "2018-10-11T01:05:45.000Z",
-                        "format": "date-time",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Outputs": {
-                        "items": {"example": "bread", "type": "string"},
-                        "nullable": true,
-                        "readOnly": true,
-                        "type": "array",
-                    },
-                    "Parameters": {
-                        "items": {"$ref": "#\/components\/schemas\/Parameter"},
-                        "type": "array",
-                    },
-                    "Public": {
-                        "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-                        "example": false,
-                        "type": "boolean",
-                    },
-                    "Status": {
-                        "description": "Status of the Workload.",
-                        "enum": [
-                            "NEW",
-                            "UPLOADING",
-                            "VALIDATING",
-                            "ACTIVE",
-                            "DELETED",
-                            "FAILED",
-                        ],
-                        "example": "NEW",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "WorkloadVersion": {
-                        "example": "0.01",
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                },
-                "required": ["Id", "Status", "ManifestURL", "WorkloadVersion"],
-                "type": "object",
-            },
-            "WorkloadTask": {
-                "allOf": [{"$ref": "#\/components\/schemas\/BaseTask"}],
-                "properties": {
-                    "Workloads": {
-                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "accounts.CreateAccount": {
-                "properties": {
-                    "AccountType": {"type": "string"},
-                    "AwsAccountId": {
-                        "description": "AWS Account Id.",
-                        "example": "012345678901",
-                        "maxLength": 12,
-                        "minLength": 12,
-                        "readOnly": true,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Account.",
-                        "example": "bakery",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["Name", "AccountType"],
-                "type": "object",
-            },
-            "accounts.CreateAccountType": {
-                "properties": {
-                    "Name": {
-                        "description": "Name of the Account Type.",
-                        "example": "Development",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    }
-                },
-                "required": ["Name"],
-                "type": "object",
-            },
-            "accounts.CreateAccountTypeResponse": {
-                "properties": {
-                    "Detail": {
-                        "properties": {
-                            "AccountType": {
-                                "properties": {
-                                    "Accounts": {"example": [], "type": "array"},
-                                    "CreatedBy": {
-                                        "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                    },
-                                    "CreatedTS": {
-                                        "description": "Created timestamp.",
-                                        "example": "2018-10-11T01:05:45.000Z",
-                                        "format": "date-time",
-                                        "nullable": true,
-                                        "readOnly": true,
-                                        "type": "string",
-                                    },
-                                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                                    "ModifiedTS": {
-                                        "description": "Modified timestamp.",
-                                        "example": "2018-10-11T01:05:45.000Z",
-                                        "format": "date-time",
-                                        "nullable": true,
-                                        "readOnly": true,
-                                        "type": "string",
-                                    },
-                                    "Name": {
-                                        "example": "Development",
-                                        "type": "string",
-                                    },
-                                    "OrganisationId": {
-                                        "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                    },
-                                    "Policies": {"example": [], "type": "array"},
-                                    "Roles": {"example": [], "type": "array"},
-                                    "Status": {
-                                        "enum": ["ACTIVE", "DELETED"],
-                                        "example": "ACTIVE",
-                                    },
-                                    "StaxCreated": {"type": "boolean"},
-                                },
-                                "type": "object",
-                            },
-                            "Message": {"type": "string"},
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OperationStatus": {
-                                "$ref": "#\/components\/schemas\/OperationStatus"
-                            },
-                            "Severity": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "DetailType": {"type": "string"},
-                },
-                "required": ["Detail", "DetailType"],
-                "type": "object",
-            },
-            "accounts.DiscoverAccounts": {"type": "object"},
-            "accounts.DiscoverAccountsResponse": {
-                "allOf": [
-                    {
-                        "properties": {
-                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TraceId": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    {"$ref": "#\/components\/schemas\/BaseEvent"},
-                    {
-                        "properties": {
-                            "Detail": {
-                                "$ref": "#\/components\/schemas\/TraceEventDetail"
-                            }
-                        }
-                    },
-                ]
-            },
-            "accounts.OnboardAccount": {
-                "properties": {
-                    "AccountType": {
-                        "anyOf": [
-                            {"example": "Development", "type": "string"},
-                            {"$ref": "#\/components\/schemas\/uuidv4"},
-                        ]
-                    },
-                    "AwsAccountId": {
-                        "description": "AWS Account Id.",
-                        "example": "012345678901",
-                        "maxLength": 12,
-                        "minLength": 12,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Account.",
-                        "example": "bakery",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["AwsAccountId", "AccountType"],
-                "type": "object",
-            },
-            "accounts.ReadAccountTypes": {
-                "properties": {
-                    "AccountTypes": {
-                        "items": {"$ref": "#\/components\/schemas\/AccountType"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "accounts.ReadAccounts": {
-                "properties": {
-                    "Accounts": {
-                        "items": {"$ref": "#\/components\/schemas\/Account"},
-                        "type": "array",
-                    },
-                    "Paging": {"$ref": "#\/components\/schemas\/Pagination"},
-                },
-                "required": ["Accounts"],
-                "type": "object",
-            },
-            "accounts.UpdateAccount": {
-                "properties": {
-                    "AccountType": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "Name": {
-                        "description": "Name of the Account.",
-                        "example": "bakery",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "type": "object",
-            },
-            "accounts.UpdateAccountResponse": {
-                "properties": {
-                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Detail": {
-                        "properties": {
-                            "Account": {
-                                "properties": {
-                                    "AccountName": {
-                                        "example": "automation",
-                                        "type": "string",
-                                    },
-                                    "AccountType": {
-                                        "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                    },
-                                    "Name": {"example": "automation", "type": "string"},
-                                    "Operation": {
-                                        "$ref": "#\/components\/schemas\/Operation"
-                                    },
-                                    "OrganisationId": {
-                                        "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                    },
-                                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                                },
-                                "type": "object",
-                            },
-                            "Message": {"type": "string"},
-                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
-                            "OperationStatus": {
-                                "$ref": "#\/components\/schemas\/OperationStatus"
-                            },
-                            "Severity": {"type": "string"},
-                            "TraceId": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    "DetailType": {"type": "string"},
-                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "TraceId": {"type": "string"},
-                },
-                "required": ["Detail", "DetailType"],
-                "type": "object",
-            },
-            "accounts.UpdateAccountType": {
-                "properties": {
-                    "Name": {
-                        "description": "Name of the Account Type.",
-                        "example": "Development",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    }
-                },
-                "type": "object",
-            },
-            "accounts.UpdateAccountTypeAccess": {
-                "properties": {
-                    "AddRoles": {
-                        "example": [
-                            {
-                                "AccountTypeId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-                                "GroupId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-                                "RoleName": "admin",
-                            }
-                        ],
-                        "items": {
-                            "$ref": "#\/components\/schemas\/AccountTypeAccessMap"
-                        },
-                        "type": "array",
-                    },
-                    "RemoveRoles": {
-                        "example": [],
-                        "items": {
-                            "$ref": "#\/components\/schemas\/AccountTypeAccessMap"
-                        },
-                        "type": "array",
-                    },
-                },
-                "type": "object",
-            },
-            "accounts.UpdateAccountTypeMembers": {
-                "properties": {
-                    "Members": {
-                        "example": [
-                            {
-                                "AccountId": "B4407766-E821-450D-B7C8-9EA38B58C432",
-                                "AccountTypeId": "B4407766-E821-450D-B7C8-9EA38B58C432",
-                            }
-                        ],
-                        "items": {
-                            "$ref": "#\/components\/schemas\/AccountTypeMemberMap"
-                        },
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "accounts.UpdatePolicies": {
-                "properties": {
-                    "AddPolicies": {
-                        "example": [
-                            {
-                                "AccountTypeId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-                                "PolicyId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-                            }
-                        ],
-                        "items": {
-                            "$ref": "#\/components\/schemas\/AccountTypePolicyMap"
-                        },
-                        "type": "array",
-                    },
-                    "RemovePolicies": {
-                        "example": [],
-                        "items": {
-                            "$ref": "#\/components\/schemas\/AccountTypePolicyMap"
-                        },
-                        "type": "array",
-                    },
-                },
-                "type": "object",
-            },
-            "gateway-endpoint": {
-                "description": "A list of gateway vpc endpoints",
-                "enum": ["dynamodb", "s3"],
-                "example": "s3",
-                "type": "string",
-            },
-            "interface-endpoint": {
-                "description": "A list of interface vpc endpoints",
-                "enum": [
-                    "access-analyzer",
-                    "application-autoscaling",
-                    "appmesh-envoy-management",
-                    "appstream.api",
-                    "appstream.streaming",
-                    "athena",
-                    "autoscaling",
-                    "autoscaling-plans",
-                    "awsconnector",
-                    "clouddirectory",
-                    "cloudformation",
-                    "cloudtrail",
-                    "codebuild",
-                    "codecommit",
-                    "codepipeline",
-                    "config",
-                    "datasync",
-                    "ec2",
-                    "ec2messages",
-                    "ecr.api",
-                    "ecr.dkr",
-                    "ecs",
-                    "ecs-agent",
-                    "ecs-telemetry",
-                    "elasticfilesystem",
-                    "elasticfilesystem-fips",
-                    "elasticloadbalancing",
-                    "events",
-                    "execute-api",
-                    "git-codecommit",
-                    "glue",
-                    "kinesis-firehose",
-                    "kinesis-streams",
-                    "kms",
-                    "logs",
-                    "monitoring",
-                    "notebook",
-                    "qldb.session",
-                    "rekognition",
-                    "sagemaker.api",
-                    "sagemaker.runtime",
-                    "secretsmanager",
-                    "servicecatalog",
-                    "sms",
-                    "sns",
-                    "sqs",
-                    "ssm",
-                    "ssmmessages",
-                    "storagegateway",
-                    "sts",
-                    "transfer",
-                    "transfer.server",
-                    "workspaces",
-                ],
-                "example": "ec2",
-                "type": "string",
-            },
-            "networking.CreateCidrExclusion": {
-                "additionalProperties": false,
-                "properties": {
-                    "Cidr": {
-                        "description": "CIDR Range in quad dot notation.",
-                        "example": "10.128.0.0\/19",
-                        "type": "string",
-                    },
-                    "Description": {
-                        "description": "Longer description of what the CIDR Exclusion is used for.",
-                        "example": "This Reservation blocks out existing legacy VPCs",
-                        "maxLength": 2048,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the CIDR Exclusion.",
-                        "example": "legacy-vpcs",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["Name", "Cidr"],
-                "type": "object",
-            },
-            "networking.CreateCidrRange": {
-                "additionalProperties": false,
-                "properties": {
-                    "Cidr": {
-                        "description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
-                        "example": "10.128.0.0\/23",
-                        "type": "string",
-                    },
-                    "Description": {
-                        "description": "Longer description of what the CIDR Range is used for.",
-                        "example": "CIDR Range used for team ABCD application 1234",
-                        "maxLength": 2048,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the CIDR Range.",
-                        "example": "prod",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["Name", "Cidr"],
-                "type": "object",
-            },
-            "networking.CreateDnsResolver": {
-                "additionalProperties": false,
-                "properties": {
-                    "Name": {
-                        "description": "Name of Stax DNS Resolver.",
-                        "example": "dns",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "NumberOfInterfaces": {
-                        "description": "The number of ENIs to attach to the Stax DNS Resolvers.",
-                        "example": 2,
-                        "type": "integer",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["Name", "NumberOfInterfaces"],
-                "type": "object",
-            },
-            "networking.CreateDnsRule": {
-                "additionalProperties": false,
-                "properties": {
-                    "DomainName": {
-                        "description": "Domain name to forward DNS queries for.",
-                        "example": "test.local",
-                        "maxLength": 128,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "ForwarderIpAddresses": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The IP Addresses to forward DNS queries to.",
-                                "example": ["192.168.0.1", "192.168.0.2"],
-                                "items": {"type": "string"},
-                                "type": "array",
-                            },
-                        ]
-                    },
-                    "Name": {
-                        "description": "Name of Stax DNS Rule.",
-                        "example": "on-premises",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["Name", "DomainName"],
-                "type": "object",
-            },
-            "networking.CreateHub": {
-                "additionalProperties": false,
-                "properties": {
-                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "AmazonSideAsn": {
-                        "description": "A private Autonomous System Number (ASN) for the Amazon side of a BGP session",
-                        "example": 64512,
-                        "maximum": 65534,
-                        "minimum": 64512,
-                        "type": "integer",
-                    },
-                    "Cidr": {
-                        "description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/22 for the Transit VPC",
-                        "example": "10.128.0.0\/22",
-                        "type": "string",
-                    },
-                    "CidrExclusions": {
-                        "items": {"$ref": "#\/components\/schemas\/CidrExclusion"},
-                        "type": "array",
-                    },
-                    "CidrRangeName": {
-                        "description": "Name of the CIDR Range where the Transit VPC lives.",
-                        "example": "myrange",
-                        "maxLength": 64,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "CreateInternetGateway": {
-                        "description": "Boolean value declaring to create an Internet Gateway",
-                        "example": true,
-                        "type": "boolean",
-                    },
-                    "CreateNatGateway": {
-                        "description": "Boolean value declaring to create NAT Gateways",
-                        "example": true,
-                        "type": "boolean",
-                    },
-                    "Description": {
-                        "description": "Longer description of what the Stax Networking Hub is used for.",
-                        "example": "This Hub is for a team ABCD applications",
-                        "maxLength": 2048,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "GatewayEndpoints": {
-                        "items": {"$ref": "#\/components\/schemas\/gateway-endpoint"},
-                        "type": "array",
-                    },
-                    "InterfaceEndpoints": {
-                        "items": {"$ref": "#\/components\/schemas\/interface-endpoint"},
-                        "type": "array",
-                    },
-                    "Name": {
-                        "description": "Name of Stax Networking Hub.",
-                        "example": "prod",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "PhzSuffix": {
-                        "description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
-                        "example": "my-domain.cloud",
-                        "type": "string",
-                    },
-                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": [
-                    "Name",
-                    "AccountId",
-                    "Region",
-                    "Cidr",
-                    "CreateNatGateway",
-                    "CreateInternetGateway",
-                ],
-                "type": "object",
-            },
-            "networking.CreateVpc": {
-                "additionalProperties": false,
-                "properties": {
-                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "CidrRangeId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "CreateInternetGateway": {
-                        "description": "Boolean value declaring to create an Internet Gateway",
-                        "example": true,
-                        "type": "boolean",
-                    },
-                    "Description": {
-                        "description": "Longer description of what the Stax VPC is used for.",
-                        "example": "VPC for a non-prod microservice",
-                        "maxLength": 2048,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "GatewayEndpoints": {
-                        "items": {"$ref": "#\/components\/schemas\/gateway-endpoint"},
-                        "type": "array",
-                    },
-                    "Name": {
-                        "description": "Name of Stax VPC",
-                        "example": "dev-ms-customers",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "PhzPrefix": {
-                        "description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
-                        "example": "dev",
-                        "type": "string",
-                    },
-                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
-                    "Size": {
-                        "description": "Size of the VPC.",
-                        "enum": ["SMALL", "MEDIUM", "LARGE"],
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "Type": {
-                        "description": "Type of VPC. The Type determines what Route Tables are attached to the VPC",
-                        "enum": ["ISOLATED", "FLAT", "SHAREDSERVICES"],
-                        "type": "string",
-                    },
-                    "Zone": {
-                        "description": "All 'Flat' VPCs in the same Zone can communicate to each other.",
-                        "example": "my-zone",
-                        "maxLength": 64,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                },
-                "required": [
-                    "Name",
-                    "CidrRangeId",
-                    "AccountId",
-                    "Region",
-                    "Size",
-                    "Type",
-                    "CreateInternetGateway",
-                ],
-                "type": "object",
-            },
-            "networking.ReadCidrExclusions": {
-                "additionalProperties": false,
-                "properties": {
-                    "Exclusions": {
-                        "items": {"$ref": "#\/components\/schemas\/CidrExclusion"},
-                        "type": "array",
-                    }
-                },
-                "required": ["Exclusions"],
-                "type": "object",
-            },
-            "networking.ReadCidrRanges": {
-                "additionalProperties": false,
-                "properties": {
-                    "Ranges": {
-                        "items": {"$ref": "#\/components\/schemas\/CidrRange"},
-                        "type": "array",
-                    }
-                },
-                "required": ["Ranges"],
-                "type": "object",
-            },
-            "networking.ReadDnsResolvers": {
-                "additionalProperties": false,
-                "properties": {
-                    "DnsResolvers": {
-                        "items": {"$ref": "#\/components\/schemas\/DNSResolver"},
-                        "type": "array",
-                    }
-                },
-                "required": ["DnsResolvers"],
-                "type": "object",
-            },
-            "networking.ReadDnsRules": {
-                "additionalProperties": false,
-                "properties": {
-                    "DnsRules": {
-                        "items": {"$ref": "#\/components\/schemas\/DNSRule"},
-                        "type": "array",
-                    }
-                },
-                "required": ["DnsRules"],
-                "type": "object",
-            },
-            "networking.ReadHubs": {
-                "additionalProperties": false,
-                "properties": {
-                    "Hubs": {
-                        "items": {"$ref": "#\/components\/schemas\/NetworkingHub"},
-                        "type": "array",
-                    }
-                },
-                "required": ["Hubs"],
-                "type": "object",
-            },
-            "networking.ReadVpcs": {
-                "additionalProperties": false,
-                "properties": {
-                    "Vpcs": {
-                        "items": {"$ref": "#\/components\/schemas\/VPC"},
-                        "type": "array",
-                    }
-                },
-                "required": ["Vpcs"],
-                "type": "object",
-            },
-            "networking.UpdateCidrExclusion": {
-                "additionalProperties": false,
-                "properties": {
-                    "Description": {
-                        "description": "Longer description of what the CIDR Exclusion is used for.",
-                        "maxLength": 2048,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the CIDR Exclusion.",
-                        "example": "data-center",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "type": "object",
-            },
-            "networking.UpdateCidrRange": {
-                "additionalProperties": false,
-                "properties": {
-                    "Description": {
-                        "description": "Longer description of what the CIDR Range is used for.",
-                        "example": "CIDR Range used for team ABCD application 1234",
-                        "maxLength": 2048,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the CIDR Range.",
-                        "example": "prod",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "type": "object",
-            },
-            "networking.UpdateDnsResolver": {
-                "additionalProperties": false,
-                "properties": {
-                    "Name": {
-                        "description": "Name of Stax DNS Resolver.",
-                        "example": "dns",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "NumberOfInterfaces": {
-                        "description": "The number of ENIs to attach to the DNS Resolvers.",
-                        "example": 2,
-                        "type": "integer",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "type": "object",
-            },
-            "networking.UpdateDnsRule": {
-                "additionalProperties": false,
-                "properties": {
-                    "ForwarderIpAddresses": {
-                        "anyOf": [
-                            {"nullable": true},
-                            {
-                                "description": "The IP Addresses to forward DNS queries to.",
-                                "example": ["192.168.0.1", "192.168.0.2"],
-                                "items": {"type": "string"},
-                                "type": "array",
-                            },
-                        ]
-                    },
-                    "Name": {
-                        "description": "Name of Stax DNS Rule.",
-                        "example": "on-premises",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "type": "object",
-            },
-            "networking.UpdateHub": {
-                "additionalProperties": false,
-                "properties": {
-                    "CreateInternetGateway": {
-                        "description": "Boolean value declaring to create an Internet Gateway",
-                        "example": true,
-                        "type": "boolean",
-                    },
-                    "CreateNatGateway": {
-                        "description": "Boolean value declaring to create NAT Gateways",
-                        "example": true,
-                        "type": "boolean",
-                    },
-                    "Description": {
-                        "description": "Longer description of what the Stax Networking Hub is used for.",
-                        "example": "This Hub is for connectivity from headquaters to VPC workloads",
-                        "maxLength": 2048,
-                        "type": "string",
-                    },
-                    "InterfaceEndpoints": {
-                        "items": {"$ref": "#\/components\/schemas\/interface-endpoint"},
-                        "type": "array",
-                    },
-                    "Name": {
-                        "description": "Name of Stax Networking Hub",
-                        "example": "prod",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "PhzSuffix": {
-                        "description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
-                        "example": "my-domain.cloud",
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "type": "object",
-            },
-            "networking.UpdateVpc": {
-                "additionalProperties": false,
-                "properties": {
-                    "CreateInternetGateway": {
-                        "description": "Boolean value declaring to create an Internet Gateway",
-                        "example": true,
-                        "type": "boolean",
-                    },
-                    "Description": {
-                        "description": "Longer description of what this VPC is used for.",
-                        "maxLength": 2048,
-                        "type": "string",
-                    },
-                    "GatewayEndpoints": {
-                        "items": {"$ref": "#\/components\/schemas\/gateway-endpoint"},
-                        "type": "array",
-                    },
-                    "Name": {
-                        "description": "Name of the Stax VPC",
-                        "example": "prod",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "PhzPrefix": {
-                        "description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
-                        "example": "dev",
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "type": "object",
-            },
-            "organisations.AttachPolicy": {
-                "properties": {"PolicyId": {"$ref": "#\/components\/schemas\/uuidv4"}},
-                "required": ["PolicyId"],
-                "type": "object",
-            },
-            "organisations.CreatePolicy": {
-                "properties": {
-                    "Description": {
-                        "description": "Description of the Policy.",
-                        "example": "A service control policy that denies access to all.",
-                        "maxLength": 1024,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Policy.",
-                        "example": "DenyAll",
-                        "maxLength": 128,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "Policy": {"type": "string"},
-                },
-                "required": ["Name", "Description", "Policy"],
-                "type": "object",
-            },
-            "organisations.ReadOrganisations": {
-                "properties": {
-                    "Organisations": {
-                        "items": {"$ref": "#\/components\/schemas\/Organisation"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "organisations.ReadPolicies": {
-                "properties": {
-                    "Policies": {
-                        "items": {"$ref": "#\/components\/schemas\/Policy"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "organisations.UpdatePolicy": {
-                "properties": {
-                    "Description": {
-                        "description": "Description of the Policy.",
-                        "example": "A service control policy that denies access to all.",
-                        "maxLength": 1024,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Policy.",
-                        "example": "DenyAll",
-                        "maxLength": 128,
-                        "minLength": 3,
-                        "type": "string",
-                    },
-                    "Policy": {"type": "string"},
-                },
-                "type": "object",
-            },
-            "ro-uuidv4": {
-                "example": "e893d7e0-9306-11e9-bc42-526af7764f64",
-                "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-                "readOnly": true,
-                "type": "string",
-            },
-            "teams.CreateApiToken": {
-                "additionalProperties": false,
-                "properties": {
-                    "Description": {
-                        "description": "Longer description of what this Token is used for.",
-                        "example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
-                        "maxLength": 1024,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of API Token",
-                        "example": "gitlab-cicd",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "pattern": "^([0-9a-zA-Z_.-]+)$",
-                        "type": "string",
-                    },
-                    "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
-                    "StoreToken": {
-                        "default": true,
-                        "description": "Store the Access and Secret key in SSM, in your security account.",
-                        "example": true,
-                        "type": "boolean",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "TokenKeyId": {
-                        "default": "alias\/stax-api-tokens",
-                        "description": "If you choose to store your keys in SSM, encrypt them with this KMS Key",
-                        "example": "alias\/my-custom-key",
-                        "maxLength": 128,
-                        "minLength": 7,
-                        "pattern": "^([a-zA-Z0-9:\/_-]+)$",
-                        "type": "string",
-                    },
-                },
-                "required": ["Name", "Role"],
-                "type": "object",
-            },
-            "teams.CreateApiTokenResponse": {
-                "properties": {
-                    "ApiTokens": {
-                        "items": {
-                            "properties": {
-                                "AccessKey": {
-                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                },
-                                "CreatedBy": {
-                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                },
-                                "CreatedTS": {
-                                    "description": "Created timestamp.",
-                                    "example": "2018-10-11T01:05:45.000Z",
-                                    "format": "date-time",
-                                    "readOnly": true,
-                                    "type": "string",
-                                },
-                                "Description": {
-                                    "description": "Longer description of what this Token is used for.",
-                                    "example": "This token is for deployment pipelines in Gitlab to deploy to dev environments",
-                                    "maxLength": 1024,
-                                    "type": "string",
-                                },
-                                "Name": {
-                                    "description": "Name of API Token",
-                                    "example": "gitlab-cicd",
-                                    "maxLength": 64,
-                                    "minLength": 2,
-                                    "pattern": "^([0-9a-zA-Z_.-]+)$",
-                                    "type": "string",
-                                },
-                                "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
-                                "SecretKey": {
-                                    "maxLength": 32,
-                                    "minLength": 32,
-                                    "type": "string",
-                                },
-                                "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                            },
-                            "required": ["AccessKey", "SecretKey"],
-                            "type": "object",
-                        },
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "teams.CreateGroup": {
-                "properties": {
-                    "Name": {
-                        "description": "Name of User Group",
-                        "example": "devops",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["Name"],
-                "type": "object",
-            },
-            "teams.CreateGroupResponse": {
-                "allOf": [
-                    {
-                        "properties": {
-                            "GroupId": {"$ref": "#\/components\/schemas\/ro-uuidv4"}
-                        },
-                        "type": "object",
-                    },
-                    {"$ref": "#\/components\/schemas\/BaseEvent"},
-                    {
-                        "properties": {
-                            "Detail": {
-                                "$ref": "#\/components\/schemas\/TraceEventDetail"
-                            }
-                        }
-                    },
-                ]
-            },
-            "teams.CreateUser": {
-                "properties": {
-                    "Email": {
-                        "description": "Email address of User.",
-                        "example": "stax.user@example.com",
-                        "format": "email",
-                        "maxLength": 128,
-                        "minLength": 6,
-                        "type": "string",
-                    },
-                    "FirstName": {
-                        "description": "Given Name of the User.",
-                        "example": "John",
-                        "maxLength": 128,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "LastName": {
-                        "description": "Family Name of the User.",
-                        "example": "Doe",
-                        "maxLength": 128,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "PhoneNumber": {
-                        "description": "Phone number of User in E.164 format.",
-                        "example": "+61491570006",
-                        "pattern": "^\\+[1-9]\\d{4,14}$",
-                        "type": "string",
-                    },
-                    "Role": {"$ref": "#\/components\/schemas\/Role"},
-                },
-                "required": ["Email", "FirstName", "LastName"],
-                "type": "object",
-            },
-            "teams.CreateUserResponse": {
-                "allOf": [
-                    {
-                        "properties": {
-                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                            "TraceId": {"type": "string"},
-                        },
-                        "type": "object",
-                    },
-                    {"$ref": "#\/components\/schemas\/BaseEvent"},
-                    {
-                        "properties": {
-                            "Detail": {
-                                "$ref": "#\/components\/schemas\/TraceEventDetail"
-                            }
-                        }
-                    },
-                ]
-            },
-            "teams.InviteRootUser": {
-                "properties": {
-                    "Email": {
-                        "description": "Email address of User.",
-                        "example": "stax.user@example.com",
-                        "format": "email",
-                        "maxLength": 128,
-                        "minLength": 6,
-                        "type": "string",
-                    }
-                },
-                "required": ["Email"],
-                "type": "object",
-            },
-            "teams.ReadApiTokens": {
-                "properties": {
-                    "ApiTokens": {
-                        "items": {
-                            "properties": {
-                                "AccessKey": {
-                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                },
-                                "CreatedBy": {
-                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                },
-                                "CreatedTS": {
-                                    "description": "Created timestamp.",
-                                    "example": "2018-10-11T01:05:45.000Z",
-                                    "format": "date-time",
-                                    "readOnly": true,
-                                    "type": "string",
-                                },
-                                "Description": {
-                                    "description": "Longer description of what this Token is used for.",
-                                    "example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
-                                    "maxLength": 1024,
-                                    "minLength": 0,
-                                    "type": "string",
-                                },
-                                "ModifiedTS": {
-                                    "description": "Modified timestamp.",
-                                    "example": "2018-10-11T01:05:45.000Z",
-                                    "format": "date-time",
-                                    "readOnly": true,
-                                    "type": "string",
-                                },
-                                "Name": {
-                                    "description": "Name of API Token",
-                                    "example": "gitlab-cicd",
-                                    "maxLength": 64,
-                                    "minLength": 2,
-                                    "pattern": "^([0-9a-zA-Z_.-]+)$",
-                                    "type": "string",
-                                },
-                                "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
-                                "Status": {
-                                    "description": "Status of the Token.",
-                                    "enum": ["ACTIVE", "DELETED"],
-                                    "example": "ACTIVE",
-                                    "type": "string",
-                                },
-                                "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                            },
-                            "type": "object",
-                        },
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "teams.ReadGroups": {
-                "properties": {
-                    "Groups": {
-                        "items": {"$ref": "#\/components\/schemas\/Group"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "teams.ReadUsers": {
-                "properties": {
-                    "Users": {
-                        "items": {"$ref": "#\/components\/schemas\/User"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "teams.UpdateApiToken": {
-                "properties": {
-                    "Description": {
-                        "description": "Longer description of what this Token is used for.",
-                        "example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
-                        "maxLength": 1024,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "type": "object",
-            },
-            "teams.UpdateApiTokenResponse": {
-                "properties": {
-                    "ApiTokens": {
-                        "items": {
-                            "properties": {
-                                "AccessKey": {
-                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                },
-                                "CreatedBy": {
-                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
-                                },
-                                "CreatedTS": {
-                                    "description": "Created timestamp.",
-                                    "example": "2018-10-11T01:05:45.000Z",
-                                    "format": "date-time",
-                                    "readOnly": true,
-                                    "type": "string",
-                                },
-                                "Description": {
-                                    "description": "Longer description of what this Token is used for.",
-                                    "example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
-                                    "maxLength": 1024,
-                                    "minLength": 0,
-                                    "type": "string",
-                                },
-                                "ModifiedTS": {
-                                    "description": "Modified timestamp.",
-                                    "example": "2018-10-11T01:05:45.000Z",
-                                    "format": "date-time",
-                                    "readOnly": true,
-                                    "type": "string",
-                                },
-                                "Name": {
-                                    "description": "Name of API Token",
-                                    "example": "gitlab-cicd",
-                                    "maxLength": 64,
-                                    "minLength": 2,
-                                    "pattern": "^([0-9a-zA-Z_.-]+)$",
-                                    "type": "string",
-                                },
-                                "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
-                                "Status": {
-                                    "description": "Status of the Token.",
-                                    "enum": ["ACTIVE", "DELETED"],
-                                    "example": "ACTIVE",
-                                    "type": "string",
-                                },
-                                "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                            },
-                            "type": "object",
-                        },
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "teams.UpdateGroup": {
-                "properties": {
-                    "Name": {
-                        "description": "Name of User Group",
-                        "example": "devops",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                },
-                "required": ["Name"],
-                "type": "object",
-            },
-            "teams.UpdateGroupMembers": {
-                "properties": {
-                    "AddMembers": {
-                        "items": {"$ref": "#\/components\/schemas\/UserGroupMemberMap"},
-                        "type": "array",
-                    },
-                    "RemoveMembers": {
-                        "items": {"$ref": "#\/components\/schemas\/UserGroupMemberMap"},
-                        "type": "array",
-                    },
-                },
-                "type": "object",
-            },
-            "teams.UpdateUser": {
-                "properties": {
-                    "Email": {
-                        "description": "Email address of User.",
-                        "example": "stax.user@example.com",
-                        "format": "email",
-                        "maxLength": 128,
-                        "minLength": 6,
-                        "type": "string",
-                    },
-                    "FirstName": {
-                        "description": "Given Name of the User.",
-                        "example": "John",
-                        "maxLength": 128,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "LastName": {
-                        "description": "Family Name of the User.",
-                        "example": "Doe",
-                        "maxLength": 128,
-                        "minLength": 0,
-                        "type": "string",
-                    },
-                    "PhoneNumber": {
-                        "description": "Phone number of User in E.164 format.",
-                        "example": "+61491570006",
-                        "pattern": "^\\+[1-9]\\d{4,14}$",
-                        "type": "string",
-                    },
-                    "Role": {"$ref": "#\/components\/schemas\/Role"},
-                    "Status": {
-                        "description": "Status of User.",
-                        "enum": ["ACTIVE", "DISABLED"],
-                        "type": "string",
-                    },
-                },
-                "type": "object",
-            },
-            "teams.UpdateUserEvent": {
-                "allOf": [
-                    {"$ref": "#\/components\/schemas\/BaseEvent"},
-                    {
-                        "properties": {
-                            "Detail": {
-                                "$ref": "#\/components\/schemas\/TraceEventDetail"
-                            }
-                        }
-                    },
-                ],
-                "type": "object",
-            },
-            "teams.UpdateUserInvite": {"type": "object"},
-            "teams.UpdateUserPassword": {"type": "object"},
-            "users.ReadIdamUsers": {
-                "properties": {
-                    "Users": {
-                        "items": {"$ref": "#\/components\/schemas\/IdamUser"},
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "uuidv4": {
-                "example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-                "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-                "type": "string",
-            },
-            "workloads.Catalogue": {
-                "properties": {
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "WorkloadCatalogueItems": {
-                        "items": {"$ref": "#\/components\/schemas\/WorkloadCatalogue"},
-                        "type": "array",
-                    },
-                },
-                "required": ["OrganisationId", "WorkloadCatalogueItems"],
-                "type": "object",
-            },
-            "workloads.CreateCatalogueItem": {
-                "properties": {
-                    "Description": {
-                        "description": "Description of the Workload.",
-                        "example": "A Workload to build a VPC in my org",
-                        "maxLength": 1024,
-                        "type": "string",
-                    },
-                    "ManifestBody": {
-                        "description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
-                        "example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
-                        "type": "string",
-                    },
-                    "ManifestURL": {
-                        "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-                        "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-                        "type": "string",
-                    },
-                    "Name": {
-                        "description": "Name of the Workload Catalogue Item to create.",
-                        "example": "my-directory-service",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "Version": {
-                        "description": "Version of the Workload Catalogue Item to create.",
-                        "example": "1.0.2",
-                        "maxLength": 128,
-                        "type": "string",
-                    },
-                },
-                "required": ["Name", "Version"],
-                "type": "object",
-            },
-            "workloads.CreateCatalogueVersion": {
-                "properties": {
-                    "Description": {
-                        "description": "Description of the Workload.",
-                        "example": "A Workload to build a VPC in my org",
-                        "maxLength": 1024,
-                        "type": "string",
-                    },
-                    "ManifestBody": {
-                        "description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
-                        "example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
-                        "type": "string",
-                    },
-                    "ManifestURL": {
-                        "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-                        "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-                        "type": "string",
-                    },
-                    "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
-                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
-                    "Version": {
-                        "description": "Version of the Workload Catalogue Item to create.",
-                        "example": "1.0.2",
-                        "maxLength": 128,
-                        "type": "string",
-                    },
-                },
-                "required": ["Version"],
-            },
-            "workloads.CreateWorkload": {
-                "properties": {
-                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "CatalogueId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "CatalogueVersionId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
-                    "Name": {
-                        "description": "The Workload name.",
-                        "example": "my-workload-is-cool",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Parameters": {
-                        "items": {"$ref": "#\/components\/schemas\/Parameter"},
-                        "type": "array",
-                    },
-                    "Region": {
-                        "description": "AWS Region the workload will be launched in",
-                        "example": "us-east-1",
-                        "maxLength": 32,
-                        "type": "string",
-                    },
-                    "Tags": {"anyOf": [{"type": "object"}, {"nullable": true}]},
-                },
-                "required": ["Name", "CatalogueId", "AccountId", "Region"],
-                "type": "object",
-            },
-            "workloads.ReadCatalogueItems": {
-                "properties": {
-                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "WorkloadCatalogues": {
-                        "items": {
-                            "$ref": "#\/components\/schemas\/workloads.Catalogue"
-                        },
-                        "type": "array",
-                    },
-                },
-                "type": "object",
-            },
-            "workloads.ReadCatalogueManifest": {
-                "properties": {"url": {"type": "string"}},
-                "required": ["url"],
-                "type": "object",
-            },
-            "workloads.ReadCatalogueTemplate": {
-                "properties": {"url": {"type": "string"}},
-                "required": ["url"],
-                "type": "object",
-            },
-            "workloads.ReadCatalogueVersion": {
-                "properties": {
-                    "Versions": {
-                        "items": {
-                            "$ref": "#\/components\/schemas\/WorkloadCatalogueVersion"
-                        },
-                        "type": "array",
-                    }
-                },
-                "type": "object",
-            },
-            "workloads.ReadWorkloads": {
-                "properties": {
-                    "Paging": {"$ref": "#\/components\/schemas\/Pagination"},
-                    "Workloads": {
-                        "items": {"$ref": "#\/components\/schemas\/Workload"},
-                        "type": "array",
-                    },
-                },
-                "required": ["Workloads"],
-                "type": "object",
-            },
-            "workloads.UpdateAll": {
-                "properties": {
-                    "CatalogueId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "CatalogueVersionId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                },
-                "required": ["CatalogueId"],
-                "type": "object",
-            },
-            "workloads.UpdateWorkload": {
-                "properties": {
-                    "CatalogueVersionId": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    "Name": {
-                        "description": "The Workload name.",
-                        "example": "my-workload-is-cool",
-                        "maxLength": 64,
-                        "minLength": 2,
-                        "type": "string",
-                    },
-                    "Tags": {"type": "object"},
-                },
-                "type": "object",
-            },
-        },
-        "securitySchemes": {
-            "sigv4": {
-                "in": "header",
-                "name": "Authorization",
-                "type": "apiKey",
-                "x-amazon-apigateway-authtype": "awsSigv4",
-            }
-        },
-    },
-    "info": {
-        "contact": {"url": "https:\/\/stax.io"},
-        "description": "The Stax API is organised around REST, uses resource-oriented URLs, return responses are JSON and uses standard HTTP response codes, authentication and verbs.",
-        "termsOfService": "\/there_is_no_tos",
-        "title": "Stax Core API",
-        "version": "None",
-    },
-    "openapi": "3.0.0",
-    "paths": {
-        "\/20190206\/account-types\/members": {
-            "put": {
-                "description": "Move Accounts between Account Types.<br\/>",
-                "operationId": "accounts.UpdateAccountTypeMembers",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/accounts.UpdateAccountTypeMembers"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is forbidden.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Account Type members",
-                "tags": ["Accounts"],
-            }
-        },
-        "\/20190206\/account-types\/policies": {
-            "put": {
-                "description": "Add Policies to Account types or Remove Policies from Account Types.<br\/>",
-                "operationId": "accounts.UpdatePolicies",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/accounts.UpdatePolicies"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Account Type Policies",
-                "tags": ["Accounts"],
-            }
-        },
-        "\/20190206\/accounts": {
-            "get": {
-                "description": "Return all AWS Accounts within your Stax Organisation.<br\/>Optionally, return the requested AWS Account.<br\/>",
-                "operationId": "accounts.ReadAccounts",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Account to return.",
-                        "in": "path",
-                        "name": "account_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The Account statuses to return, comma delimited.\n\nFilter options available: INITIALIZING, ACTIVE, SUSPENDED, MAINTENANCE, AWSERROR, CLOSED, OFFBOARDED, DISCOVERED, ERROR.\n",
-                        "in": "query",
-                        "name": "filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Account IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The Account Type IDs to return, comma delimited.\n",
-                        "in": "query",
-                        "name": "account_type_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Pagination - The page number to return.",
-                        "in": "query",
-                        "name": "offset",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "Pagination - The number of items per page to return.",
-                        "in": "query",
-                        "name": "limit",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "The field to sort on.",
-                        "in": "query",
-                        "name": "sort",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The sort order - up or down?",
-                        "in": "query",
-                        "name": "sort_order",
-                        "required": false,
-                        "schema": {
-                            "default": "DESC",
-                            "enum": ["ASC", "DESC"],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "Do you want all the Tags?",
-                        "in": "query",
-                        "name": "include_tags",
-                        "required": false,
-                        "schema": {"default": true, "type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.ReadAccounts"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Accounts",
-                "tags": ["Accounts"],
-            },
-            "post": {
-                "description": "Create a new Stax-hardened AWS Account in your Stax Organisation.<br\/>",
-                "operationId": "accounts.CreateAccount",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/accounts.CreateAccount"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create Account",
-                "tags": ["Accounts"],
-            },
-        },
-        "\/20190206\/accounts\/discover": {
-            "post": {
-                "description": "Discover all AWS Accounts associated with the org into stax<br\/>Optionally attempt to rediscover an Aws Account that failed discovery<br\/>",
-                "operationId": "accounts.DiscoverAccounts",
-                "parameters": [
-                    {
-                        "description": "The AWS Account Id of the Account to discover.",
-                        "in": "path",
-                        "name": "aws_account_id",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.DiscoverAccountsResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful due to user input.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the account given has already been discovered.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the requested account cannot be discovered.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Discover Accounts",
-                "tags": ["Accounts"],
-            }
-        },
-        "\/20190206\/accounts\/discover\/{aws_account_id}": {
-            "post": {
-                "description": "Discover all AWS Accounts associated with the org into stax<br\/>Optionally attempt to rediscover an Aws Account that failed discovery<br\/>",
-                "operationId": "accounts.DiscoverAccounts",
-                "parameters": [
-                    {
-                        "description": "The AWS Account Id of the Account to discover.",
-                        "in": "path",
-                        "name": "aws_account_id",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.DiscoverAccountsResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful due to user input.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the account given has already been discovered.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the requested account cannot be discovered.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Discover Accounts",
-                "tags": ["Accounts"],
-            }
-        },
-        "\/20190206\/accounts\/onboard": {
-            "post": {
-                "description": "Onboard an existing AWS Account to your Stax Organisation.<br\/>",
-                "operationId": "accounts.OnboardAccount",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/accounts.OnboardAccount"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Onboard AWS Account",
-                "tags": ["Accounts"],
-            }
-        },
-        "\/20190206\/accounts\/types": {
-            "get": {
-                "description": "Return all the Account Types in your Stax Organisation.<br\/>Optionally, return the requested Account Type.<br\/>",
-                "operationId": "accounts.ReadAccountTypes",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Account Type.",
-                        "in": "path",
-                        "name": "account_type_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of AccountType IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Account Types",
-                "tags": ["Accounts"],
-            },
-            "post": {
-                "description": "Create a new Account Type within your Stax Organisation.<br\/>Account Types can be used to set Policies on Accounts and control Group access.<br\/>",
-                "operationId": "accounts.CreateAccountType",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/accounts.CreateAccountType"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.CreateAccountTypeResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is forbidden.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create Account Type",
-                "tags": ["Accounts"],
-            },
-        },
-        "\/20190206\/accounts\/types\/access": {
-            "put": {
-                "description": "Adjust the AWS role permissions between Account Types and Groups.<br\/>",
-                "operationId": "accounts.UpdateAccountTypeAccess",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/accounts.UpdateAccountTypeAccess"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update AWS access",
-                "tags": ["Accounts"],
-            }
-        },
-        "\/20190206\/accounts\/types\/{account_type_id}": {
-            "delete": {
-                "description": "Delete an Account Type from your Stax Organisation.<br\/>An Account Type can only be deleted if there are no attached Accounts.<br\/>",
-                "operationId": "accounts.DeleteAccountType",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Catalogue item.",
-                        "in": "path",
-                        "name": "account_type_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is forbidden.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete Account Type",
-                "tags": ["Accounts"],
-            },
-            "get": {
-                "description": "Return all the Account Types in your Stax Organisation.<br\/>Optionally, return the requested Account Type.<br\/>",
-                "operationId": "accounts.ReadAccountTypes",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Account Type.",
-                        "in": "path",
-                        "name": "account_type_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of AccountType IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Account Types",
-                "tags": ["Accounts"],
-            },
-            "put": {
-                "description": "Change the details of an Account Type, such as the name.<br\/>",
-                "operationId": "accounts.UpdateAccountType",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Account Type to update.",
-                        "in": "path",
-                        "name": "account_type_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/accounts.UpdateAccountType"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is forbidden.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Account Type",
-                "tags": ["Accounts"],
-            },
-        },
-        "\/20190206\/accounts\/{account_id}": {
-            "get": {
-                "description": "Return all AWS Accounts within your Stax Organisation.<br\/>Optionally, return the requested AWS Account.<br\/>",
-                "operationId": "accounts.ReadAccounts",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Account to return.",
-                        "in": "path",
-                        "name": "account_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The Account statuses to return, comma delimited.\n\nFilter options available: INITIALIZING, ACTIVE, SUSPENDED, MAINTENANCE, AWSERROR, CLOSED, OFFBOARDED, DISCOVERED, ERROR.\n",
-                        "in": "query",
-                        "name": "filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Account IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The Account Type IDs to return, comma delimited.\n",
-                        "in": "query",
-                        "name": "account_type_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Pagination - The page number to return.",
-                        "in": "query",
-                        "name": "offset",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "Pagination - The number of items per page to return.",
-                        "in": "query",
-                        "name": "limit",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "The field to sort on.",
-                        "in": "query",
-                        "name": "sort",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The sort order - up or down?",
-                        "in": "query",
-                        "name": "sort_order",
-                        "required": false,
-                        "schema": {
-                            "default": "DESC",
-                            "enum": ["ASC", "DESC"],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "Do you want all the Tags?",
-                        "in": "query",
-                        "name": "include_tags",
-                        "required": false,
-                        "schema": {"default": true, "type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.ReadAccounts"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Accounts",
-                "tags": ["Accounts"],
-            },
-            "put": {
-                "description": "Change the details of an Account, such as the name, tags or Account Type<br\/>",
-                "operationId": "accounts.UpdateAccount",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Account to update.",
-                        "in": "path",
-                        "name": "account_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/accounts.UpdateAccount"
-                            }
-                        }
-                    },
-                    "required": false,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is forbidden.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Account",
-                "tags": ["Accounts"],
-            },
-        },
-        "\/20190206\/api-tokens": {
-            "get": {
-                "description": "Return a list of all API Tokens within your Stax Organisation.<br\/>",
-                "operationId": "teams.ReadApiTokens",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Token to return.",
-                        "in": "path",
-                        "name": "AccessKey",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Access Keys you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: ACTIVE, DELETED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {"default": "ACTIVE", "type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.ReadApiTokens"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch API Tokens",
-                "tags": ["Team", "Beta"],
-            },
-            "post": {
-                "description": "Create an API Token for API\/SDK access within your Stax Organisation.<br\/>",
-                "operationId": "teams.CreateApiToken",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/teams.CreateApiToken"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.CreateApiTokenResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create API Token",
-                "tags": ["Team", "Beta"],
-            },
-        },
-        "\/20190206\/api-tokens\/{AccessKey}": {
-            "delete": {
-                "description": "Delete an API Token from your Stax Organisation.<br\/>",
-                "operationId": "teams.DeleteApiToken",
-                "parameters": [
-                    {
-                        "description": "The UUID of the User to delete.",
-                        "in": "path",
-                        "name": "AccessKey",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.UpdateApiTokenResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete API Token",
-                "tags": ["Team", "Beta"],
-            },
-            "get": {
-                "description": "Return a list of all API Tokens within your Stax Organisation.<br\/>",
-                "operationId": "teams.ReadApiTokens",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Token to return.",
-                        "in": "path",
-                        "name": "AccessKey",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Access Keys you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: ACTIVE, DELETED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {"default": "ACTIVE", "type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.ReadApiTokens"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch API Tokens",
-                "tags": ["Team", "Beta"],
-            },
-            "put": {
-                "description": "Update a Token for API\/SDK access within your Stax Organisation.<br\/>",
-                "operationId": "teams.UpdateApiToken",
-                "parameters": [
-                    {
-                        "description": "The UUID of the API Token to update.",
-                        "in": "path",
-                        "name": "AccessKey",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/teams.UpdateApiToken"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.UpdateApiTokenResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update API Token",
-                "tags": ["Team", "Beta"],
-            },
-        },
-        "\/20190206\/groups": {
-            "get": {
-                "description": "Return all Groups within your Stax Organisation.<br\/>Optionally, return the requested Group.<br\/>",
-                "operationId": "teams.ReadGroups",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Group to return.",
-                        "in": "path",
-                        "name": "group_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Group IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.ReadGroups"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Groups",
-                "tags": ["Groups"],
-            },
-            "post": {
-                "description": "Create a new Group within your Stax Organisation.<br\/>",
-                "operationId": "teams.CreateGroup",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/teams.CreateGroup"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.CreateGroupResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create Group",
-                "tags": ["Groups"],
-            },
-        },
-        "\/20190206\/groups\/members": {
-            "put": {
-                "description": "Add members to a Group or Remove members from a Group<br\/>",
-                "operationId": "teams.UpdateGroupMembers",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/teams.UpdateGroupMembers"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "Could not locate user or group.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Group Members",
-                "tags": ["Groups"],
-            }
-        },
-        "\/20190206\/groups\/{group_id}": {
-            "delete": {
-                "description": "Delete a Group from your Stax Organisation.<br\/>A Group can only be deleted if there are no team members in the Group.<br\/>",
-                "operationId": "teams.DeleteGroup",
-                "parameters": [
-                    {
-                        "description": "The UUID of Group to delete.",
-                        "in": "path",
-                        "name": "group_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The Group still contains members.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The Group could not be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete Group",
-                "tags": ["Groups"],
-            },
-            "get": {
-                "description": "Return all Groups within your Stax Organisation.<br\/>Optionally, return the requested Group.<br\/>",
-                "operationId": "teams.ReadGroups",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Group to return.",
-                        "in": "path",
-                        "name": "group_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Group IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.ReadGroups"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Groups",
-                "tags": ["Groups"],
-            },
-            "put": {
-                "description": "Change the details of a Group, such as the name.<br\/>",
-                "operationId": "teams.UpdateGroup",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Group to update.",
-                        "in": "path",
-                        "name": "group_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/teams.UpdateGroup"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Group",
-                "tags": ["Groups"],
-            },
-        },
-        "\/20190206\/idam\/user": {
-            "get": {
-                "deprecated": true,
-                "description": "(DEPRECATED) Return a list of all IDAM Users in your Stax Organisation.<br\/>",
-                "operationId": "teams.ReadIdamUsers",
-                "parameters": [
-                    {
-                        "description": "The Organisation ID in which the IDAM is deployed to.  If no org_id is supplied, the Customer's default Organisation will be used.",
-                        "in": "path",
-                        "name": "org_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Do you want all the Tags?",
-                        "in": "query",
-                        "name": "include_tags",
-                        "required": false,
-                        "schema": {"default": true, "type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/users.ReadIdamUsers"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch IDAM Users",
-                "tags": ["IDAM", "Deprecated"],
-            },
-            "post": {
-                "description": "Create a new Stax user within your Stax Organisation.<br\/>Stax Users have permission to access the AWS Console\/CLI for AWS Accounts that exist within a Stax Organisation.<br\/>",
-                "operationId": "teams.CreateUser",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/teams.CreateUser"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.CreateUserResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create Stax User",
-                "tags": ["Team"],
-            },
-        },
-        "\/20190206\/idam\/user\/resend-invite\/{user_id}": {
-            "put": {
-                "description": "Re-send the verification email for a Stax User.<br\/>",
-                "operationId": "teams.UpdateUserInvite",
-                "parameters": [
-                    {
-                        "description": "The UUID of the IDAM User to re-invite.",
-                        "in": "path",
-                        "name": "user_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.UpdateUserEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the user has already verified their email address.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the user does not exist in IDAM.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Re-invite Stax user",
-                "tags": ["Team"],
-            }
-        },
-        "\/20190206\/idam\/user\/reset-password\/{user_id}": {
-            "put": {
-                "description": "Send a Stax User a password reset email.<br\/>",
-                "operationId": "teams.UpdateUserPassword",
-                "parameters": [
-                    {
-                        "description": "The UUID of the IDAM User to have password reset.",
-                        "in": "path",
-                        "name": "user_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.UpdateUserEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the user has been deleted.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Reset Stax User's password",
-                "tags": ["Team"],
-            }
-        },
-        "\/20190206\/idam\/user\/{org_id}": {
-            "get": {
-                "deprecated": true,
-                "description": "(DEPRECATED) Return a list of all IDAM Users in your Stax Organisation.<br\/>",
-                "operationId": "teams.ReadIdamUsers",
-                "parameters": [
-                    {
-                        "description": "The Organisation ID in which the IDAM is deployed to.  If no org_id is supplied, the Customer's default Organisation will be used.",
-                        "in": "path",
-                        "name": "org_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Do you want all the Tags?",
-                        "in": "query",
-                        "name": "include_tags",
-                        "required": false,
-                        "schema": {"default": true, "type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/users.ReadIdamUsers"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch IDAM Users",
-                "tags": ["IDAM", "Deprecated"],
-            }
-        },
-        "\/20190206\/idam\/user\/{user_id}": {
-            "put": {
-                "description": "Update a Stax User's details, such as the name, role or email.<br\/>",
-                "operationId": "teams.UpdateUser",
-                "parameters": [
-                    {
-                        "description": "The UUID of the IDAM User to update.",
-                        "in": "path",
-                        "name": "user_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/teams.UpdateUser"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.CreateUserResponse"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Stax User",
-                "tags": ["Team"],
-            }
-        },
-        "\/20190206\/networking\/dnsresolvers\/{dns_resolver_id}": {
-            "delete": {
-                "description": "<br\/>Deletes a Stax DNS Resolver within a Stax Networking Hub.<br\/>",
-                "operationId": "networking.DeleteDnsResolver",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax DNS Resolver to delete.",
-                        "in": "path",
-                        "name": "dns_resolver_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax DNS Resolver to delete cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete DNS Resolver",
-                "tags": ["Beta"],
-            },
-            "get": {
-                "description": "<br\/>Returns the DNS Resolver of the Stax Networking Hub.<br\/>Providing the UUID of a Stax DNS Resolver will return a specific Stax DNS Resolver's details.<br\/>",
-                "operationId": "networking.ReadDnsResolvers",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax Networking Hub where the Stax DNS Resolver is deployed.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Stax DNS Resolver to fetch.",
-                        "in": "path",
-                        "name": "dns_resolver_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Stax DNS Resolver statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {
-                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-                            "type": "string",
-                        },
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadDnsResolvers"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch DNS Resolvers",
-                "tags": ["Beta"],
-            },
-            "put": {
-                "description": "<br\/>Updates the attributes for a given Stax DNS Resolver. Only supplied values are updated.<br\/>",
-                "operationId": "networking.UpdateDnsResolver",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax DNS Resolver to update.",
-                        "in": "path",
-                        "name": "dns_resolver_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.UpdateDnsResolver"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax DNS Resolver to update cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update DNS Resolver",
-                "tags": ["Beta"],
-            },
-        },
-        "\/20190206\/networking\/dnsresolvers\/{dns_resolver_id}\/dnsrules": {
-            "get": {
-                "description": "<br\/>Returns the Stax DNS Rules of the Stax DNS Resolver.<br\/>Providing the UUID of a Stax DNS Rule will return a specific Stax DNS Rule's details.<br\/>",
-                "operationId": "networking.ReadDnsRules",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax DNS Resolver.",
-                        "in": "path",
-                        "name": "dns_resolver_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Stax DNS Rule to fetch.",
-                        "in": "path",
-                        "name": "dns_rule_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Stax DNS Rule statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {
-                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-                            "type": "string",
-                        },
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadDnsRules"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch DNS Rules",
-                "tags": ["Beta"],
-            },
-            "post": {
-                "description": "<br\/>Creates a Stax DNS Rule within a Stax DNS Resolver.<br\/>",
-                "operationId": "networking.CreateDnsRule",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax DNS Resolver to create the Stax DNS Rule within.",
-                        "in": "path",
-                        "name": "dns_resolver_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.CreateDnsRule"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax DNS Resolver to create the Stax DNS Rule within cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create DNS Rule",
-                "tags": ["Beta"],
-            },
-        },
-        "\/20190206\/networking\/dnsrules\/{dns_rule_id}": {
-            "delete": {
-                "description": "<br\/>Deletes a Stax DNS Rule within a Stax DNS Resolver<br\/>",
-                "operationId": "networking.DeleteDnsRule",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax DNS Rule.",
-                        "in": "path",
-                        "name": "dns_rule_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax DNS Rule to delete cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete DNS Rule",
-                "tags": ["Beta"],
-            },
-            "get": {
-                "description": "<br\/>Returns the Stax DNS Rules of the Stax DNS Resolver.<br\/>Providing the UUID of a Stax DNS Rule will return a specific Stax DNS Rule's details.<br\/>",
-                "operationId": "networking.ReadDnsRules",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax DNS Resolver.",
-                        "in": "path",
-                        "name": "dns_resolver_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Stax DNS Rule to fetch.",
-                        "in": "path",
-                        "name": "dns_rule_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Stax DNS Rule statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {
-                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-                            "type": "string",
-                        },
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadDnsRules"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch DNS Rules",
-                "tags": ["Beta"],
-            },
-            "put": {
-                "description": "<br\/>Updates the attributes for a given Stax DNS Rule. Only supplied values are updated.<br\/>",
-                "operationId": "networking.UpdateDnsRule",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax DNS Rule to update.",
-                        "in": "path",
-                        "name": "dns_rule_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.UpdateDnsRule"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax DNS Rule to update cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update DNS Rule",
-                "tags": ["Beta"],
-            },
-        },
-        "\/20190206\/networking\/exclusions": {
-            "get": {
-                "description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
-                "operationId": "networking.ReadCidrExclusions",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub to list Exclusions in.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Exclusion to read.",
-                        "in": "path",
-                        "name": "exclusion_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {"default": "ACTIVE", "type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch CIDR Exclusions",
-                "tags": ["Networking"],
-            }
-        },
-        "\/20190206\/networking\/exclusions\/{exclusion_id}": {
-            "delete": {
-                "description": "<br\/>Deletes a CIDR Exclusion within a Stax Networking Hub.<br\/>",
-                "operationId": "networking.DeleteCidrExclusion",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub to delete the CIDR Exclusion.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Exclusion to Delete.",
-                        "in": "path",
-                        "name": "exclusion_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The CIDR Exclusion to delete cannot be found or is already deleted.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete CIDR Exclusion",
-                "tags": ["Networking"],
-            },
-            "get": {
-                "description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
-                "operationId": "networking.ReadCidrExclusions",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub to list Exclusions in.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Exclusion to read.",
-                        "in": "path",
-                        "name": "exclusion_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {"default": "ACTIVE", "type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch CIDR Exclusions",
-                "tags": ["Networking"],
-            },
-            "put": {
-                "description": "<br\/>Updates a CIDR Exclusion within a Stax Networking Hub<br\/>",
-                "operationId": "networking.UpdateCidrExclusion",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub to update the CIDR Exclusion.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Exclusion to update.",
-                        "in": "path",
-                        "name": "exclusion_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.UpdateCidrExclusion"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.UpdateCidrExclusion"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The CIDR Exclusion to update cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update CIDR Exclusion",
-                "tags": ["Networking"],
-            },
-        },
-        "\/20190206\/networking\/hubs": {
-            "get": {
-                "description": "<br\/>Returns a list of networking hubs in your Stax Organisation.<br\/>Can use the UUID of a Hub to return a specific hub details.<br\/>",
-                "operationId": "networking.ReadHubs",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, UPDATE_IN_PROGRESS, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {
-                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-                            "type": "string",
-                        },
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadHubs"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Networking Hubs",
-                "tags": ["Networking"],
-            },
-            "post": {
-                "description": "<br\/>Creates Stax Networking Hub within your Stax Organisation.<br\/>",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.CreateHub"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The account to deploy a hub does not exist.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create Networking Hub",
-                "tags": ["Networking"],
-            },
-        },
-        "\/20190206\/networking\/hubs\/{hub_id}": {
-            "delete": {
-                "description": "<br\/>Deletes a hub from the Stax Organisation<br\/>",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub to delete.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The hub to be deleted doesn't exist or is already deleted.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete Networking Hub",
-                "tags": ["Networking"],
-            },
-            "get": {
-                "description": "<br\/>Returns a list of networking hubs in your Stax Organisation.<br\/>Can use the UUID of a Hub to return a specific hub details.<br\/>",
-                "operationId": "networking.ReadHubs",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, UPDATE_IN_PROGRESS, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {
-                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-                            "type": "string",
-                        },
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadHubs"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Networking Hubs",
-                "tags": ["Networking"],
-            },
-            "put": {
-                "description": "<br\/>Updates a various attributes for a given hub. Only supplied values are updated.<br\/>",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub to update.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.UpdateHub"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "An active hub to be updated does not exist",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Networking Hub",
-                "tags": ["Networking"],
-            },
-        },
-        "\/20190206\/networking\/hubs\/{hub_id}\/dnsresolvers": {
-            "get": {
-                "description": "<br\/>Returns the DNS Resolver of the Stax Networking Hub.<br\/>Providing the UUID of a Stax DNS Resolver will return a specific Stax DNS Resolver's details.<br\/>",
-                "operationId": "networking.ReadDnsResolvers",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax Networking Hub where the Stax DNS Resolver is deployed.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Stax DNS Resolver to fetch.",
-                        "in": "path",
-                        "name": "dns_resolver_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Stax DNS Resolver statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {
-                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-                            "type": "string",
-                        },
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadDnsResolvers"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch DNS Resolvers",
-                "tags": ["Beta"],
-            },
-            "post": {
-                "description": "<br\/>Creates a Stax DNS Resolver within a Stax Networking Hub.<br\/>",
-                "operationId": "networking.CreateDnsResolver",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Stax Networking Hub to deploy the Stax DNS Resolver.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.CreateDnsResolver"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Stax Networking Hub to deploy the Stax DNS Resolver cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create DNS Resolver",
-                "tags": ["Beta"],
-            },
-        },
-        "\/20190206\/networking\/hubs\/{hub_id}\/exclusions": {
-            "get": {
-                "description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
-                "operationId": "networking.ReadCidrExclusions",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub to list Exclusions in.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Exclusion to read.",
-                        "in": "path",
-                        "name": "exclusion_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {"default": "ACTIVE", "type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch CIDR Exclusions",
-                "tags": ["Networking"],
-            },
-            "post": {
-                "description": "<br\/>Creates a CIDR Exclusion within a Stax Networking Hub<br\/>",
-                "operationId": "networking.CreateCidrExclusion",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub where the CIDR Exclusion is created in.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.CreateCidrExclusion"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The hub to create the CIDR Exclusion is not found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create CIDR Exclusion",
-                "tags": ["Networking"],
-            },
-        },
-        "\/20190206\/networking\/hubs\/{hub_id}\/ranges": {
-            "get": {
-                "description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
-                "operationId": "networking.ReadCidrRanges",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub you want the Ranges for.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Range to read.",
-                        "in": "path",
-                        "name": "range_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {"default": "ACTIVE", "type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch CIDR Ranges",
-                "tags": ["Networking"],
-            },
-            "post": {
-                "description": "<br\/>Creates a CIDR Range within a Stax Networking Hub<br\/>",
-                "operationId": "networking.CreateCidrRange",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub where the CIDR Range is created in.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.CreateCidrRange"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The hub to create the CIDR Range is not found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create CIDR Range",
-                "tags": ["Networking"],
-            },
-        },
-        "\/20190206\/networking\/hubs\/{hub_id}\/vpcs": {
-            "get": {
-                "description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
-                "operationId": "networking.ReadVpcs",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub where the VPC is.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the VPC to read.",
-                        "in": "path",
-                        "name": "vpc_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {
-                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
-                        "in": "query",
-                        "name": "type",
-                        "required": false,
-                        "schema": {
-                            "default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
-                            "type": "string",
-                        },
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadVpcs"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch VPCs",
-                "tags": ["Networking"],
-            },
-            "post": {
-                "description": "<br\/>Creates a VPC within a Stax Networking Hub<br\/>",
-                "operationId": "networking.CreateVpc",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub where the VPC is.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.CreateVpc"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "No permission to create VPC in the specified AWS Account",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The hub to create the VPC is not found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create VPC",
-                "tags": ["Networking"],
-            },
-        },
-        "\/20190206\/networking\/ranges": {
-            "get": {
-                "description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
-                "operationId": "networking.ReadCidrRanges",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub you want the Ranges for.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Range to read.",
-                        "in": "path",
-                        "name": "range_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {"default": "ACTIVE", "type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch CIDR Ranges",
-                "tags": ["Networking"],
-            }
-        },
-        "\/20190206\/networking\/ranges\/{range_id}": {
-            "delete": {
-                "description": "<br\/>Deletes a CIDR Range within a Stax Networking Hub. No existing VPCs can be in the CIDR Range.<br\/>",
-                "operationId": "networking.DeleteCidrRange",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub to delete the CIDR Range.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Range to delete.",
-                        "in": "path",
-                        "name": "range_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The CIDR Range to delete cannot be found or is already deleted.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete CIDR Range",
-                "tags": ["Networking"],
-            },
-            "get": {
-                "description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
-                "operationId": "networking.ReadCidrRanges",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub you want the Ranges for.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the Range to read.",
-                        "in": "path",
-                        "name": "range_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {"default": "ACTIVE", "type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch CIDR Ranges",
-                "tags": ["Networking"],
-            },
-            "put": {
-                "description": "<br\/>Updates a CIDR Range within a Stax Networking Hub<br\/>",
-                "operationId": "networking.UpdateCidrRange",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub to update the CIDR Range.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the CIDR Range to update.",
-                        "in": "path",
-                        "name": "range_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.UpdateCidrRange"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.UpdateCidrRange"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The CIDR Range to update cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update CIDR Range",
-                "tags": ["Networking"],
-            },
-        },
-        "\/20190206\/networking\/vpcs": {
-            "get": {
-                "description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
-                "operationId": "networking.ReadVpcs",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub where the VPC is.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the VPC to read.",
-                        "in": "path",
-                        "name": "vpc_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {
-                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
-                        "in": "query",
-                        "name": "type",
-                        "required": false,
-                        "schema": {
-                            "default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
-                            "type": "string",
-                        },
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadVpcs"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch VPCs",
-                "tags": ["Networking"],
-            }
-        },
-        "\/20190206\/networking\/vpcs\/{vpc_id}": {
-            "delete": {
-                "description": "<br\/>Deletes a VPC within a Stax Networking Hub<br\/>",
-                "operationId": "networking.DeleteVpc",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub where the VPC is.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the VPC to delete.",
-                        "in": "path",
-                        "name": "vpc_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The VPC to delete cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete VPC",
-                "tags": ["Networking"],
-            },
-            "get": {
-                "description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
-                "operationId": "networking.ReadVpcs",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub where the VPC is.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the VPC to read.",
-                        "in": "path",
-                        "name": "vpc_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-                        "in": "query",
-                        "name": "status",
-                        "required": false,
-                        "schema": {
-                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
-                        "in": "query",
-                        "name": "type",
-                        "required": false,
-                        "schema": {
-                            "default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
-                            "type": "string",
-                        },
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/networking.ReadVpcs"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch VPCs",
-                "tags": ["Networking"],
-            },
-            "put": {
-                "description": "<br\/>Updates a VPC within a Stax Networking Hub<br\/>",
-                "operationId": "networking.UpdateVpc",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Hub where the VPC is.",
-                        "in": "path",
-                        "name": "hub_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                    {
-                        "description": "The UUID of the VPC to update.",
-                        "in": "path",
-                        "name": "vpc_id",
-                        "required": true,
-                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
-                    },
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/networking.UpdateVpc"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The VPC to update cannot be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update VPC",
-                "tags": ["Networking"],
-            },
-        },
-        "\/20190206\/organisations": {
-            "get": {
-                "description": "Return a list of your Stax Organisations.<br\/>A Stax Organisation is an instance of Stax which houses your AWS Accounts, Workloads and IDAM Users.<br\/>",
-                "operationId": "organisations.ReadOrganisations",
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/organisations.ReadOrganisations"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful. The response body contains an Organisation array.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Stax Organisations",
-                "tags": ["Organisations"],
-            }
-        },
-        "\/20190206\/organisations\/current": {
-            "get": {
-                "description": "Return the current users Organisation.<br\/>A Stax Organisation is an instance of Stax which houses your AWS Accounts, Workloads and IDAM Users.<br\/>",
-                "operationId": "organisations.ReadOrganisation",
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/organisations.ReadOrganisations"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful. The response body contains an Organisation array.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Stax Organisations",
-                "tags": ["Organisations"],
-            }
-        },
-        "\/20190206\/policies": {
-            "get": {
-                "description": "Return all Policies in your Stax Organisation.<br\/>Optionally, return the requested Policy.<br\/>",
-                "operationId": "organisations.ReadPolicies",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Policy to return.",
-                        "in": "path",
-                        "name": "policy_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/organisations.ReadPolicies"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Policies",
-                "tags": ["Policies"],
-            },
-            "post": {
-                "description": "Create a Policy in your Stax Organisation.<br\/>",
-                "operationId": "organisations.CreatePolicy",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/organisations.CreatePolicy"
-                            }
-                        }
-                    },
-                    "required": false,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/CreatePolicyEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create Policy",
-                "tags": ["Policies"],
-            },
-        },
-        "\/20190206\/policies\/organisation\/{policy_id}": {
-            "delete": {
-                "description": "Detach a Policy from your Stax Organisation.<br\/>The policy will no longer apply to all Account Types within the Organisation.<br\/>",
-                "operationId": "organisations:DetachPolicy",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Policy to detach.",
-                        "in": "path",
-                        "name": "policy_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Detach Policy from Organisation",
-                "tags": ["Policies"],
-            },
-            "put": {
-                "description": "Attach a Policy to your Stax Organisation.<br\/>The policy will apply to all Account Types within the Organisation.<br\/>",
-                "operationId": "organisations:AttachPolicy",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Policy to attach.",
-                        "in": "path",
-                        "name": "policy_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/organisations.AttachPolicy"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "Unable to attach foundation policy to an Organisation.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Attach Policy to Organisation",
-                "tags": ["Policies"],
-            },
-        },
-        "\/20190206\/policies\/{policy_id}": {
-            "delete": {
-                "description": "Delete a Policy from your Stax Organisation.<br\/>",
-                "operationId": "organisations.DeletePolicy",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Policy to delete.",
-                        "in": "path",
-                        "name": "policy_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/DeletePolicyEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete Policy",
-                "tags": ["Policies"],
-            },
-            "get": {
-                "description": "Return all Policies in your Stax Organisation.<br\/>Optionally, return the requested Policy.<br\/>",
-                "operationId": "organisations.ReadPolicies",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Policy to return.",
-                        "in": "path",
-                        "name": "policy_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/organisations.ReadPolicies"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Policies",
-                "tags": ["Policies"],
-            },
-            "put": {
-                "description": "Update an existing Policy within your Stax Organisation.<br\/>",
-                "operationId": "organisations.UpdatePolicy",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Policy to update.",
-                        "in": "path",
-                        "name": "policy_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/organisations.UpdatePolicy"
-                            }
-                        }
-                    },
-                    "required": false,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/UpdatePolicyEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Policy",
-                "tags": ["Policies"],
-            },
-        },
-        "\/20190206\/public\/check-alias\/{alias}": {
-            "get": {
-                "description": "Check if an Alias is available or if it is already in use by another Stax customer.<br\/>The Alias is the unique identifier for a Customer's Stax Organisation.<br\/>",
-                "operationId": "public.CheckAlias",
-                "parameters": [
-                    {
-                        "description": "A unique string containing characters a-z, A-Z, 0-9.\nHyphens can also be used, but not at the start or end of the alias.\n",
-                        "in": "path",
-                        "name": "alias",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Alias"}
-                            }
-                        },
-                        "description": "The response returned if the Alias is available and not in use by another Customer.",
-                    },
-                    "409": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/AliasInUse"}
-                            }
-                        },
-                        "description": "The Alias is already in use by another Customer.",
-                    },
-                },
-                "summary": "Check Alias availability",
-                "tags": ["Public"],
-            }
-        },
-        "\/20190206\/public\/config": {
-            "get": {
-                "description": "This is an unauthenticated endpoint returning your configuration variables which are required to authenticate API requests.<br\/>",
-                "operationId": "public.ReadConfig",
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Config"}
-                            }
-                        },
-                        "description": "Configuration values required to authenicate API requests.",
-                    }
-                },
-                "summary": "Fetch public config",
-                "tags": ["Public"],
-            }
-        },
-        "\/20190206\/task\/{task_id}": {
-            "get": {
-                "description": "Return the status of the requested Task.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
-                "operationId": "tasks.ReadTask",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Task to return.",
-                        "in": "path",
-                        "name": "task_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Task"}
-                            }
-                        },
-                        "description": "The response returned for a valid Task.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the requested Task could not be found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch status of Task",
-                "tags": ["Tasks"],
-            }
-        },
-        "\/20190206\/tasks": {
-            "get": {
-                "description": "Return all Tasks for your Stax Organisation.<br\/>Optionally, return all tasks with the specified status for your Stax Organisation.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
-                "operationId": "tasks.ReadTasks",
-                "parameters": [
-                    {
-                        "description": "Return all tasks of this status.\n\nAccepted values are: RUNNING, SUCCEEDED or FAILED.\n",
-                        "in": "path",
-                        "name": "task_status",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/GetTasks"}
-                            }
-                        },
-                        "description": "The Tasks returned for a valid task_status.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The task_status not supplied or invalid.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch all Tasks by status",
-                "tags": ["Tasks"],
-            }
-        },
-        "\/20190206\/tasks\/{task_status}": {
-            "get": {
-                "description": "Return all Tasks for your Stax Organisation.<br\/>Optionally, return all tasks with the specified status for your Stax Organisation.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
-                "operationId": "tasks.ReadTasks",
-                "parameters": [
-                    {
-                        "description": "Return all tasks of this status.\n\nAccepted values are: RUNNING, SUCCEEDED or FAILED.\n",
-                        "in": "path",
-                        "name": "task_status",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/GetTasks"}
-                            }
-                        },
-                        "description": "The Tasks returned for a valid task_status.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The task_status not supplied or invalid.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch all Tasks by status",
-                "tags": ["Tasks"],
-            }
-        },
-        "\/20190206\/users": {
-            "get": {
-                "description": "Return a list of all Users within your Stax Organisation.<br\/>Optionally, return the requested User.<br\/>",
-                "operationId": "teams.ReadUsers",
-                "parameters": [
-                    {
-                        "description": "The UUID of the User to return.",
-                        "in": "path",
-                        "name": "user_id",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Users filtered by auth origin, comma delimited.\n\nFilter Options available: Team, Federated, Root\n",
-                        "in": "query",
-                        "name": "filter",
-                        "required": false,
-                        "schema": {"default": "Team", "type": "string"},
-                    },
-                    {
-                        "description": "List of User IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Users filtered by Status, comma delimited.\n\nFilter Options available: ACTIVE, NEW, INVITED, DISABLED, DELETED\n",
-                        "in": "query",
-                        "name": "status_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Stax Users, Federated Users, Root Users and API Tokens",
-                "tags": ["Team"],
-            }
-        },
-        "\/20190206\/users\/invite": {
-            "post": {
-                "description": "Invite a new Root User to your Stax Organisation.<br\/>",
-                "operationId": "teams.InviteRootUser",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/teams.InviteRootUser"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "Only Root users can invite new Root users.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Invite New Root User",
-                "tags": ["Team"],
-            }
-        },
-        "\/20190206\/users\/me": {
-            "get": {
-                "description": "Returns the current logged in User.<br\/>",
-                "operationId": "teams.ReadUsers",
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Current User",
-                "tags": ["Team"],
-            }
-        },
-        "\/20190206\/users\/{user_id}": {
-            "delete": {
-                "description": "Delete a Stax User from your Stax Organisation.<br\/>",
-                "operationId": "teams.DeleteUser",
-                "parameters": [
-                    {
-                        "description": "The UUID of the User to delete.",
-                        "in": "path",
-                        "name": "user_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "User not found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete Stax User",
-                "tags": ["Team"],
-            },
-            "get": {
-                "description": "Return a list of all Users within your Stax Organisation.<br\/>Optionally, return the requested User.<br\/>",
-                "operationId": "teams.ReadUsers",
-                "parameters": [
-                    {
-                        "description": "The UUID of the User to return.",
-                        "in": "path",
-                        "name": "user_id",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Users filtered by auth origin, comma delimited.\n\nFilter Options available: Team, Federated, Root\n",
-                        "in": "query",
-                        "name": "filter",
-                        "required": false,
-                        "schema": {"default": "Team", "type": "string"},
-                    },
-                    {
-                        "description": "List of User IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Users filtered by Status, comma delimited.\n\nFilter Options available: ACTIVE, NEW, INVITED, DISABLED, DELETED\n",
-                        "in": "query",
-                        "name": "status_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    }
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Stax Users, Federated Users, Root Users and API Tokens",
-                "tags": ["Team"],
-            },
-        },
-        "\/20190206\/workload-catalogue": {
-            "get": {
-                "description": "Return all Workload Catalogue Items within your Stax Organisation.<br\/>Optionally, return the requested Workload Catalogue Item.<br\/>",
-                "operationId": "workloads.ReadCatalogueItems",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Catalogue Item to return.",
-                        "in": "path",
-                        "name": "catalogue_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The Name of the Workload Catalogue Items to return.",
-                        "in": "query",
-                        "name": "name",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload Catalogue Item statuses you want returned, comma delimited.\n\nFilter options available: STARTED, RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED.\n",
-                        "in": "query",
-                        "name": "filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload Catalogue Item IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Pagination - The page number to return.",
-                        "in": "query",
-                        "name": "offset",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "Pagination - The number of items per page to return.",
-                        "in": "query",
-                        "name": "limit",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "The field to sort on.",
-                        "in": "query",
-                        "name": "sort",
-                        "required": false,
-                        "schema": {
-                            "enum": [
-                                "Id",
-                                "Name",
-                                "Description",
-                                "Status",
-                                "OrganisationId",
-                                "Public",
-                                "CreatedTS",
-                                "CreatedBy",
-                                "ModifiedTS",
-                                "UserTaskId",
-                                "CatalogueVersionId",
-                                "Protection",
-                            ],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "The sort order - up or down.",
-                        "in": "query",
-                        "name": "sort_order",
-                        "required": false,
-                        "schema": {
-                            "default": "DESC",
-                            "enum": ["ASC", "DESC"],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "Do you want all Versions?",
-                        "in": "query",
-                        "name": "include_versions",
-                        "required": false,
-                        "schema": {"default": true, "type": "boolean"},
-                    },
-                    {
-                        "description": "Do you want the Parameter dictionary?",
-                        "in": "query",
-                        "name": "include_parameters",
-                        "required": false,
-                        "schema": {"default": true, "type": "boolean"},
-                    },
-                    {
-                        "description": "Do you want all the Tags?",
-                        "in": "query",
-                        "name": "include_tags",
-                        "required": false,
-                        "schema": {"default": false, "type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueItems"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if an invalid ID is entered.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if no catalogue is found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Workload Catalogue Items",
-                "tags": ["Workloads"],
-            },
-            "post": {
-                "description": "Create a new Workload Catalogue Item within your Stax Organisation.<br\/>",
-                "operationId": "workloads.CreateCatalogueItem",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/workloads.CreateCatalogueItem"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/CreateCatalogueEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Create Workload Catalogue Item",
-                "tags": ["Workloads"],
-            },
-        },
-        "\/20190206\/workload-catalogue\/manifest\/{version_id}": {
-            "get": {
-                "description": "Return a Workload Catalogue Manifest<br\/>",
-                "operationId": "workloads.ReadCatalogueManifest",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Catalogue Version",
-                        "in": "path",
-                        "name": "version_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueManifest"
-                                }
-                            }
-                        },
-                        "description": "Returns the presigned url for the manifest file",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if an invalid ID is entered.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is not successful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Workload Catalogue Manifest",
-                "tags": ["Workloads"],
-            }
-        },
-        "\/20190206\/workload-catalogue\/template\/{version_id}\/{name}": {
-            "get": {
-                "description": "Return a specific Workload Catalogue Cloudformation Template<br\/>",
-                "operationId": "workloads.ReadCatalogueTemplate",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Catalogue Version",
-                        "in": "path",
-                        "name": "version_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Retrieve the Cloudformation with this Resource Name.",
-                        "in": "path",
-                        "name": "name",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueTemplate"
-                                }
-                            }
-                        },
-                        "description": "Returns the presigned url to retrieve the template",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if an invalid ID is entered.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is not successful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Workload Catalogue Cloudformation Template",
-                "tags": ["Workloads"],
-            }
-        },
-        "\/20190206\/workload-catalogue\/{catalogue_id}": {
-            "delete": {
-                "description": "Delete a Workload Catalogue Item from your Stax Organisation.<br\/>Existing Workloads launched from this Catalogue will not be deleted.<br\/>",
-                "operationId": "workloads.DeleteCatalogueItem",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Catalogue Item to delete.",
-                        "in": "path",
-                        "name": "catalogue_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/DeleteCatalogueEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Workload Catalogue can not be deleted due to running workloads.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Workload Catalogue is Protected. Protection must be disabled before you can delete it.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Workload Catalogue can not be found or does not belong to the user.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete Workload Catalogue Item",
-                "tags": ["Workloads"],
-            },
-            "get": {
-                "description": "Return all Workload Catalogue Items within your Stax Organisation.<br\/>Optionally, return the requested Workload Catalogue Item.<br\/>",
-                "operationId": "workloads.ReadCatalogueItems",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Catalogue Item to return.",
-                        "in": "path",
-                        "name": "catalogue_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The Name of the Workload Catalogue Items to return.",
-                        "in": "query",
-                        "name": "name",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload Catalogue Item statuses you want returned, comma delimited.\n\nFilter options available: STARTED, RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED.\n",
-                        "in": "query",
-                        "name": "filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload Catalogue Item IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Pagination - The page number to return.",
-                        "in": "query",
-                        "name": "offset",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "Pagination - The number of items per page to return.",
-                        "in": "query",
-                        "name": "limit",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "The field to sort on.",
-                        "in": "query",
-                        "name": "sort",
-                        "required": false,
-                        "schema": {
-                            "enum": [
-                                "Id",
-                                "Name",
-                                "Description",
-                                "Status",
-                                "OrganisationId",
-                                "Public",
-                                "CreatedTS",
-                                "CreatedBy",
-                                "ModifiedTS",
-                                "UserTaskId",
-                                "CatalogueVersionId",
-                                "Protection",
-                            ],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "The sort order - up or down.",
-                        "in": "query",
-                        "name": "sort_order",
-                        "required": false,
-                        "schema": {
-                            "default": "DESC",
-                            "enum": ["ASC", "DESC"],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "Do you want all Versions?",
-                        "in": "query",
-                        "name": "include_versions",
-                        "required": false,
-                        "schema": {"default": true, "type": "boolean"},
-                    },
-                    {
-                        "description": "Do you want the Parameter dictionary?",
-                        "in": "query",
-                        "name": "include_parameters",
-                        "required": false,
-                        "schema": {"default": true, "type": "boolean"},
-                    },
-                    {
-                        "description": "Do you want all the Tags?",
-                        "in": "query",
-                        "name": "include_tags",
-                        "required": false,
-                        "schema": {"default": false, "type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueItems"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if an invalid ID is entered.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if no catalogue is found.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Workload Catalogue Items",
-                "tags": ["Workloads"],
-            },
-            "put": {
-                "description": "Creates a new version of a Workload Catalogue Item.<br\/>Workload Catalogue Items have one or more versions and are immutable, so any changes are a new version.<br\/>",
-                "operationId": "workloads.CreateCatalogueVersion",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Catalogue Item to update.",
-                        "in": "path",
-                        "name": "catalogue_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/workloads.CreateCatalogueVersion"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/CreateVersionEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Workload Catalogue Item",
-                "tags": ["Workloads"],
-            },
-        },
-        "\/20190206\/workload-catalogue\/{catalogue_id}\/{version_id}": {
-            "delete": {
-                "description": "Delete a Workload Catalogue Version from your Stax Organisation.<br\/>Existing Workloads launched from this Workload Catalogue Version will not be deleted.<br\/>",
-                "operationId": "workloads.DeleteCatalogueVersion",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Catalogue Item.",
-                        "in": "path",
-                        "name": "catalogue_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The UUID of the Catalogue Version to delete.",
-                        "in": "path",
-                        "name": "version_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/DeleteVersionEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Workload Catalogue Version can not be deleted due to running workloads.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Workload Catalogue Version can not be found or does not belong to the user.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Delete Workload Catalogue Version",
-                "tags": ["Workloads"],
-            },
-            "get": {
-                "description": "Return a specific Workload Catalogue Version.<br\/>",
-                "operationId": "workloads.ReadCatalogueVersion",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Catalogue Item to return.",
-                        "in": "path",
-                        "name": "catalogue_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The UUID of the Catalogue Version to return.",
-                        "in": "path",
-                        "name": "version_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Do you want the Parameter dictionary?",
-                        "in": "query",
-                        "name": "include_parameters",
-                        "required": false,
-                        "schema": {"default": true, "type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueVersion"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if an invalid ID is entered.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is not successful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Workload Catalogue Version",
-                "tags": ["Workloads"],
-            },
-        },
-        "\/20190206\/workload-update": {
-            "post": {
-                "deprecated": true,
-                "description": "(DEPRECATED) Update all active Workloads for a specific Workload Catalogue Item.<br\/>",
-                "operationId": "workloads.UpdateAll",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/workloads.UpdateAll"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the Catalogue is not owned by the User.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update All Workloads",
-                "tags": ["Workloads", "Deprecated"],
-            }
-        },
-        "\/20190206\/workloads": {
-            "get": {
-                "description": "Return a list of all Workloads available within your Stax Organisation.<br\/>Optionally, return the requested Workload.<br\/>",
-                "operationId": "workloads.ReadWorkloads",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Workload Item to return.",
-                        "in": "path",
-                        "name": "workload_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The Name of the Workloads to return.",
-                        "in": "query",
-                        "name": "name",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: NEW, INITIALIZING, ACTIVE, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED, UPDATE_IN_PROGRESS, UPDATE_FAILED, UPDATE_COMPLETE.\n",
-                        "in": "query",
-                        "name": "filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Only return Workloads launched from this Catalogue Version.",
-                        "in": "query",
-                        "name": "catalogue_version_id",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Pagination - The page number to return. Must be used with limit",
-                        "in": "query",
-                        "name": "offset",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "Pagination - The number of items per page to return. Must be used with offset",
-                        "in": "query",
-                        "name": "limit",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "The field to sort on.",
-                        "in": "query",
-                        "name": "sort",
-                        "required": false,
-                        "schema": {
-                            "enum": [
-                                "Id",
-                                "Name",
-                                "AccountId",
-                                "CatalogueId",
-                                "CatalogueVersionId",
-                                "Region",
-                                "Status",
-                                "UserTaskId",
-                                "CreatedBy",
-                                "CreatedTS",
-                                "ModifiedTS",
-                                "FactoryVersion",
-                            ],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "The sort order - up or down.",
-                        "in": "query",
-                        "name": "sort_order",
-                        "required": false,
-                        "schema": {
-                            "default": "DESC",
-                            "enum": ["ASC", "DESC"],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "Do you want all the Tags?",
-                        "in": "query",
-                        "name": "include_tags",
-                        "required": false,
-                        "schema": {"default": false, "type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/workloads.ReadWorkloads"
-                                }
-                            }
-                        },
-                        "description": "A list of all Workloads for the logged in Customer.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the Workload ID is not a valid UUID.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the Workload ID does not exist.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Workloads",
-                "tags": ["Workloads"],
-            },
-            "post": {
-                "description": "Deploy a Workload within an AWS Account.<br\/>",
-                "operationId": "workloads.CreateWorkload",
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {"$ref": "#\/components\/schemas\/Workload"}
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/CreateWorkloadEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Deploy Workload",
-                "tags": ["Workloads"],
-            },
-        },
-        "\/20190206\/workloads\/{workload_id}": {
-            "delete": {
-                "description": "Terminate an active Workload within an AWS Account.<br\/>",
-                "operationId": "workloads.DeleteWorkload",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Workload to delete.",
-                        "in": "path",
-                        "name": "workload_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/DeleteWorkloadEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                    "403": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The Workload is Protected. Protection must be disabled before you can delete it.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The Workload can not be found or does not belong to the user.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Terminate Workload",
-                "tags": ["Workloads"],
-            },
-            "get": {
-                "description": "Return a list of all Workloads available within your Stax Organisation.<br\/>Optionally, return the requested Workload.<br\/>",
-                "operationId": "workloads.ReadWorkloads",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Workload Item to return.",
-                        "in": "path",
-                        "name": "workload_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "The Name of the Workloads to return.",
-                        "in": "query",
-                        "name": "name",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: NEW, INITIALIZING, ACTIVE, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED, UPDATE_IN_PROGRESS, UPDATE_FAILED, UPDATE_COMPLETE.\n",
-                        "in": "query",
-                        "name": "filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "List of Workload IDs you want returned, comma delimited.",
-                        "in": "query",
-                        "name": "id_filter",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Only return Workloads launched from this Catalogue Version.",
-                        "in": "query",
-                        "name": "catalogue_version_id",
-                        "required": false,
-                        "schema": {"type": "string"},
-                    },
-                    {
-                        "description": "Pagination - The page number to return. Must be used with limit",
-                        "in": "query",
-                        "name": "offset",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "Pagination - The number of items per page to return. Must be used with offset",
-                        "in": "query",
-                        "name": "limit",
-                        "required": false,
-                        "schema": {"type": "integer"},
-                    },
-                    {
-                        "description": "The field to sort on.",
-                        "in": "query",
-                        "name": "sort",
-                        "required": false,
-                        "schema": {
-                            "enum": [
-                                "Id",
-                                "Name",
-                                "AccountId",
-                                "CatalogueId",
-                                "CatalogueVersionId",
-                                "Region",
-                                "Status",
-                                "UserTaskId",
-                                "CreatedBy",
-                                "CreatedTS",
-                                "ModifiedTS",
-                                "FactoryVersion",
-                            ],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "The sort order - up or down.",
-                        "in": "query",
-                        "name": "sort_order",
-                        "required": false,
-                        "schema": {
-                            "default": "DESC",
-                            "enum": ["ASC", "DESC"],
-                            "type": "string",
-                        },
-                    },
-                    {
-                        "description": "Do you want all the Tags?",
-                        "in": "query",
-                        "name": "include_tags",
-                        "required": false,
-                        "schema": {"default": false, "type": "boolean"},
-                    },
-                ],
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/workloads.ReadWorkloads"
-                                }
-                            }
-                        },
-                        "description": "A list of all Workloads for the logged in Customer.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the Workload ID is not a valid UUID.",
-                    },
-                    "404": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/Error"}
-                            }
-                        },
-                        "description": "The response returned if the Workload ID does not exist.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Fetch Workloads",
-                "tags": ["Workloads"],
-            },
-            "put": {
-                "description": "Update a Workload running within an AWS Account.<br\/>",
-                "operationId": "workloads.UpdateWorkload",
-                "parameters": [
-                    {
-                        "description": "The UUID of the Workload to update.",
-                        "in": "path",
-                        "name": "workload_id",
-                        "required": true,
-                        "schema": {"type": "string"},
-                    }
-                ],
-                "requestBody": {
-                    "content": {
-                        "application\/json": {
-                            "schema": {
-                                "$ref": "#\/components\/schemas\/workloads.UpdateWorkload"
-                            }
-                        }
-                    },
-                    "required": true,
-                },
-                "responses": {
-                    "200": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {
-                                    "$ref": "#\/components\/schemas\/UpdateWorkloadEvent"
-                                }
-                            }
-                        },
-                        "description": "The response returned if the request is successful.",
-                    },
-                    "400": {
-                        "content": {
-                            "application\/json": {
-                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
-                            }
-                        },
-                        "description": "The response returned if the request is unsuccessful.",
-                    },
-                },
-                "security": [{"sigv4": []}],
-                "summary": "Update Workload",
-                "tags": ["Workloads"],
-            },
-        },
-    },
-    "servers": [{"url": "https:\/\/api.au1.staxapp.cloud"}],
+	"components": {
+		"requestBodies": {},
+		"responses": {},
+		"schemas": {
+			"Account": {
+				"properties": {
+					"AWSLoginURLs": {
+						"properties": {
+							"admin": {
+								"type": "string"
+							},
+							"developer": {
+								"type": "string"
+							},
+							"readonly": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"AccountType": {
+						"type": "string"
+					},
+					"AllocatedTS": {
+						"description": "Allocated timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"AssuranceState": {
+						"description": "Hardening state of the Account.",
+						"enum": [
+							"NONE",
+							"UPDATING",
+							"ACTIVE",
+							"ERROR"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"AssuranceStateReason": {
+						"description": "Descriptive reason for the current AssuranceState.",
+						"example": "AWS GuardDuty Hardening has failed",
+						"readOnly": true,
+						"type": "string"
+					},
+					"AwsAccountId": {
+						"description": "AWS Account Id.",
+						"example": "012345678901",
+						"maxLength": 12,
+						"minLength": 12,
+						"readOnly": true,
+						"type": "string"
+					},
+					"AwsAccountStatusId": {
+						"type": "string"
+					},
+					"AwsLoginURL": {
+						"type": "string"
+					},
+					"CreatedBy": {
+						"description": "UUID of the account creator.",
+						"example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+						"pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+						"readOnly": true,
+						"type": "string"
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Email": {
+						"description": "Email address of account owner.",
+						"example": "stax.user@example.com",
+						"format": "email",
+						"maxLength": 128,
+						"minLength": 6,
+						"readOnly": true,
+						"type": "string"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"LatestCost": {
+						"example": 72.52,
+						"readOnly": true,
+						"type": "number"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2019-03-11T01:11:40.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Account.",
+						"example": "bakery",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"OrgsOuId": {
+						"type": "string"
+					},
+					"Origin": {
+						"description": "Origin of the Account.",
+						"enum": [
+							"STAX",
+							"External"
+						],
+						"example": "STAX",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Status": {
+						"description": "Status of the Account.",
+						"enum": [
+							"ACTIVE",
+							"AWSERROR",
+							"CLOSED",
+							"DISCOVERED",
+							"ERROR",
+							"INITIALIZING",
+							"MAINTENANCE",
+							"NEW",
+							"NOAWS",
+							"SUSPENDED"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"StaxCreated": {
+						"type": "boolean"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"UserTaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"required": [
+					"OrganisationId",
+					"Name"
+				],
+				"type": "object"
+			},
+			"AccountTask": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseTask"
+					}
+				],
+				"properties": {
+					"Accounts": {
+						"items": {
+							"$ref": "#\/components\/schemas\/ro-uuidv4"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"AccountType": {
+				"properties": {
+					"Accounts": {
+						"example": [],
+						"type": "array"
+					},
+					"CreatedBy": {
+						"description": "UUID of the account creator.",
+						"example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+						"nullable": true,
+						"pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+						"readOnly": true,
+						"type": "string"
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of Account Type.",
+						"example": "Development",
+						"maxLength": 64,
+						"minLength": 3,
+						"type": "string"
+					},
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Policies": {
+						"example": [],
+						"type": "array"
+					},
+					"Roles": {
+						"example": [],
+						"type": "array"
+					},
+					"Status": {
+						"enum": [
+							"ACTIVE",
+							"DELETED"
+						],
+						"example": "ACTIVE"
+					},
+					"StaxCreated": {
+						"type": "boolean"
+					}
+				},
+				"required": [
+					"OrganisationId",
+					"Name"
+				],
+				"type": "object"
+			},
+			"AccountTypeAccessMap": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"AccountTypeId",
+							"GroupId",
+							"RoleName"
+						]
+					},
+					{
+						"required": [
+							"AccountTypeName",
+							"GroupId",
+							"RoleName"
+						]
+					},
+					{
+						"required": [
+							"AccountTypeId",
+							"GroupName",
+							"RoleName"
+						]
+					},
+					{
+						"required": [
+							"AccountTypeName",
+							"GroupName",
+							"RoleName"
+						]
+					}
+				],
+				"properties": {
+					"AccountTypeId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"AccountTypeName": {
+						"type": "string"
+					},
+					"GroupId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"GroupName": {
+						"type": "string"
+					},
+					"RoleName": {
+						"$ref": "#\/components\/schemas\/AwsAccessRole"
+					}
+				},
+				"type": "object"
+			},
+			"AccountTypeMemberMap": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"AccountTypeId",
+							"AccountId"
+						]
+					},
+					{
+						"required": [
+							"AccountTypeName",
+							"AccountId"
+						]
+					}
+				],
+				"properties": {
+					"AccountId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"AccountTypeId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"AccountTypeName": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"AccountTypePolicyMap": {
+				"additionalProperties": false,
+				"anyOf": [
+					{
+						"required": [
+							"AccountTypeId",
+							"PolicyId"
+						]
+					},
+					{
+						"required": [
+							"AccountTypeName",
+							"PolicyId"
+						]
+					}
+				],
+				"properties": {
+					"AccountTypeId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"AccountTypeName": {
+						"type": "string"
+					},
+					"PolicyId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"Alias": {
+				"properties": {
+					"Alias": {
+						"properties": {
+							"Status": {
+								"enum": [
+									"The company alias provided is available",
+									"The company alias provided is already in use by another customer and cannot be used"
+								],
+								"example": "The company alias provided is available",
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"AliasInUse": {
+				"properties": {
+					"Alias": {
+						"properties": {
+							"Status": {
+								"enum": [
+									"The company alias provided is available",
+									"The company alias provided is already in use by another customer and cannot be used"
+								],
+								"example": "The company alias provided is already in use by another customer and cannot be used",
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"ApiRole": {
+				"description": "Stax role assigned to an API Token.",
+				"enum": [
+					"api_admin",
+					"api_user",
+					"api_readonly"
+				],
+				"type": "string"
+			},
+			"AwsAccessRole": {
+				"description": "AWS access roles enabled for an account type.",
+				"enum": [
+					"admin",
+					"developer",
+					"readonly"
+				],
+				"type": "string"
+			},
+			"AwsRegion": {
+				"description": "AWS Region",
+				"enum": [
+					"ap-northeast-1",
+					"ap-northeast-2",
+					"ap-south-1",
+					"ap-southeast-1",
+					"ap-southeast-2",
+					"ca-central-1",
+					"eu-central-1",
+					"eu-north-1",
+					"eu-west-1",
+					"eu-west-2",
+					"eu-west-3",
+					"sa-east-1",
+					"us-east-1",
+					"us-east-2",
+					"us-west-1",
+					"us-west-2"
+				],
+				"type": "string"
+			},
+			"BaseEvent": {
+				"properties": {
+					"DetailType": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"BaseEventDetail": {
+				"properties": {
+					"Message": {
+						"type": "string"
+					},
+					"Operation": {
+						"$ref": "#\/components\/schemas\/Operation"
+					},
+					"OperationStatus": {
+						"$ref": "#\/components\/schemas\/OperationStatus"
+					},
+					"Severity": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"BaseTask": {
+				"properties": {
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Status": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"CidrExclusion": {
+				"additionalProperties": false,
+				"properties": {
+					"Cidr": {
+						"description": "CIDR Range in quad dot notation.",
+						"example": "10.128.0.0\/19",
+						"type": "string"
+					},
+					"CreatedBy": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Description": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "Longer description of what the CIDR Exclusion is used for.",
+								"example": "datacenter exclusion",
+								"maxLength": 512,
+								"minLength": 0,
+								"type": "string"
+							}
+						]
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the CIDR Exclusion.",
+						"example": "non-prod",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"NetworkingHubId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"Status": {
+						"description": "The status of the CIRD Exclusion.",
+						"enum": [
+							"ACTIVE",
+							"DELETED",
+							"CREATE_FAILED",
+							"DELETE_FAILED"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name",
+					"Cidr"
+				],
+				"type": "object"
+			},
+			"CidrRange": {
+				"properties": {
+					"Cidr": {
+						"description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
+						"example": "10.128.0.0\/23",
+						"type": "string"
+					},
+					"CreatedBy": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"DefaultCidrRange": {
+						"description": "Boolean value declaring if the range is the default CIDR Range",
+						"example": false,
+						"type": "boolean"
+					},
+					"Description": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "Longer description of what the CIDR Range is used for.",
+								"example": "datacenter ranges",
+								"maxLength": 512,
+								"minLength": 0,
+								"type": "string"
+							}
+						]
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"LastAllocationTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the CIDR Range.",
+						"example": "non-prod",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"NetworkingHubId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Status": {
+						"description": "The status of the CIDR Range.",
+						"enum": [
+							"ACTIVE",
+							"DELETED",
+							"CREATE_FAILED",
+							"DELETE_FAILED"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name",
+					"Cidr"
+				],
+				"type": "object"
+			},
+			"Config": {
+				"properties": {
+					"API": {
+						"properties": {
+							"endpoints": {
+								"items": {
+									"$ref": "#\/components\/schemas\/ConfigEndpoint"
+								},
+								"type": "array"
+							}
+						},
+						"type": "object"
+					},
+					"Analytics": {
+						"properties": {
+							"disable": {
+								"type": "boolean"
+							}
+						},
+						"type": "object"
+					},
+					"ApiAuth": {
+						"properties": {
+							"identityPoolId": {
+								"type": "string"
+							},
+							"mandatorySignIn": {
+								"type": "boolean"
+							},
+							"region": {
+								"$ref": "#\/components\/schemas\/AwsRegion"
+							},
+							"userPoolId": {
+								"type": "string"
+							},
+							"userPoolWebClientId": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"AppSync": {
+						"properties": {
+							"analytics": {
+								"properties": {
+									"endpoint": {
+										"type": "string"
+									},
+									"region": {
+										"$ref": "#\/components\/schemas\/AwsRegion"
+									}
+								},
+								"type": "object"
+							},
+							"core": {
+								"properties": {
+									"endpoint": {
+										"type": "string"
+									},
+									"region": {
+										"$ref": "#\/components\/schemas\/AwsRegion"
+									}
+								},
+								"type": "object"
+							},
+							"graphqlEndpoint": {
+								"type": "string"
+							},
+							"region": {
+								"$ref": "#\/components\/schemas\/AwsRegion"
+							}
+						},
+						"type": "object"
+					},
+					"Auth": {
+						"properties": {
+							"identityPoolId": {
+								"type": "string"
+							},
+							"mandatorySignIn": {
+								"type": "boolean"
+							},
+							"region": {
+								"$ref": "#\/components\/schemas\/AwsRegion"
+							},
+							"userPoolId": {
+								"type": "string"
+							},
+							"userPoolWebClientId": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"Juma": {
+						"properties": {
+							"controlplaneRegion": {
+								"type": "string"
+							},
+							"domainName": {
+								"type": "string"
+							},
+							"fullDomainName": {
+								"type": "string"
+							},
+							"masterAccountId": {
+								"type": "string"
+							},
+							"rootOrgId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"stage": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"JumaAuth": {
+						"properties": {
+							"identityPoolId": {
+								"type": "string"
+							},
+							"mandatorySignIn": {
+								"type": "boolean"
+							},
+							"region": {
+								"$ref": "#\/components\/schemas\/AwsRegion"
+							},
+							"userPoolId": {
+								"type": "string"
+							},
+							"userPoolWebClientId": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"Pingdom": {
+						"properties": {
+							"key": {
+								"nullable": true,
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"SNS": {
+						"properties": {
+							"event": {
+								"type": "string"
+							},
+							"notify": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"Sentry": {
+						"properties": {
+							"dsn": {
+								"type": "string"
+							},
+							"projectName": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"Storage": {
+						"properties": {
+							"bucket": {
+								"type": "string"
+							},
+							"region": {
+								"$ref": "#\/components\/schemas\/AwsRegion"
+							}
+						},
+						"type": "object"
+					},
+					"Zone": {
+						"properties": {
+							"key": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"required": [
+					"Auth",
+					"API"
+				],
+				"type": "object"
+			},
+			"ConfigEndpoint": {
+				"properties": {
+					"endpoint": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"region": {
+						"$ref": "#\/components\/schemas\/AwsRegion"
+					}
+				},
+				"type": "object"
+			},
+			"CreateCatalogueDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"TraceId": {
+						"type": "string"
+					},
+					"WorkloadCatalogueItem": {
+						"properties": {
+							"CatalogueId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Description": {
+								"description": "Description of the Workload.",
+								"example": "A Workload to build a VPC in my org",
+								"maxLength": 1024,
+								"type": "string"
+							},
+							"ManifestURL": {
+								"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+								"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+								"type": "string"
+							},
+							"Name": {
+								"description": "Name of the Workload Catalogue Item to create.",
+								"example": "my-directory-service",
+								"maxLength": 64,
+								"minLength": 2,
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Public": {
+								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+								"example": false,
+								"type": "boolean"
+							},
+							"Tags": {
+								"$ref": "#\/components\/schemas\/Tags"
+							},
+							"Version": {
+								"example": "0.01",
+								"readOnly": true,
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"CreateCatalogueEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"CatalogueId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CustomerId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Detail": {
+						"$ref": "#\/components\/schemas\/CreateCatalogueDetail"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"TraceId": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"CreatePolicyDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"Policy": {
+						"properties": {
+							"CreatedBy": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"CustomerId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Description": {
+								"description": "Description of the Policy.",
+								"example": "A service control policy that denies access to all.",
+								"maxLength": 1024,
+								"minLength": 3,
+								"type": "string"
+							},
+							"Name": {
+								"description": "Name of the Policy.",
+								"example": "DenyAll",
+								"maxLength": 128,
+								"minLength": 3,
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OrgId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Policy": {
+								"type": "string"
+							},
+							"PolicyId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TaskId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TraceId": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"CreatePolicyEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"Detail": {
+						"$ref": "#\/components\/schemas\/CreatePolicyDetail"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"CreateVersionDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"TraceId": {
+						"type": "string"
+					},
+					"WorkloadCatalogueItem": {
+						"properties": {
+							"CatalogueId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Description": {
+								"description": "Description of the Workload.",
+								"example": "A Workload to build a VPC in my org",
+								"maxLength": 1024,
+								"type": "string"
+							},
+							"ManifestBody": {
+								"description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
+								"example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
+								"type": "string"
+							},
+							"ManifestURL": {
+								"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+								"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Parameters": {
+								"$ref": "#\/components\/schemas\/Parameter"
+							},
+							"Public": {
+								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+								"example": false,
+								"type": "boolean"
+							},
+							"Version": {
+								"example": "0.01",
+								"readOnly": true,
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"CreateVersionEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"CatalogueId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CustomerId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Detail": {
+						"$ref": "#\/components\/schemas\/CreateVersionDetail"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"TraceId": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"CreateWorkloadDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"Workload": {
+						"properties": {
+							"AccountId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"CatalogueId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"CatalogueVersionId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"CreatedBy": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Name": {
+								"description": "The Workload name.",
+								"example": "my-workload-is-cool",
+								"maxLength": 64,
+								"minLength": 2,
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OrgId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"Parameters": {
+								"$ref": "#\/components\/schemas\/Parameter"
+							},
+							"Region": {
+								"description": "AWS Region the workload will be launched in",
+								"example": "us-east-1",
+								"maxLength": 32,
+								"type": "string"
+							},
+							"Tags": {
+								"$ref": "#\/components\/schemas\/Tags"
+							},
+							"TaskId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"TraceId": {
+								"type": "string"
+							},
+							"WorkloadId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"CreateWorkloadEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"Detail": {
+						"$ref": "#\/components\/schemas\/CreateWorkloadDetail"
+					},
+					"WorkloadId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"Customer": {
+				"properties": {
+					"CognitoUserId": {
+						"description": "Cognito User unique identifier.",
+						"example": "my-user-id",
+						"readOnly": true,
+						"type": "string"
+					},
+					"CreatedBy": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Email": {
+						"description": "Email address of the User.",
+						"example": "stax.user@example.com",
+						"format": "email",
+						"maxLength": 128,
+						"minLength": 6,
+						"type": "string"
+					},
+					"FactoryVersion": {
+						"$ref": "#\/components\/schemas\/GitHash"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Account.",
+						"example": "My Business",
+						"maxLength": 64,
+						"minLength": 3,
+						"type": "string"
+					},
+					"Status": {
+						"description": "Status of the Customer.",
+						"enum": [
+							"PROSPECT",
+							"NEW",
+							"INITIALIZING",
+							"ACTIVE",
+							"SUSPENDED"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"SupportPlan": {
+						"description": "Stax Support Plan allocated to the Customer.",
+						"enum": [
+							"BASIC",
+							"BUSINESS",
+							"ENTERPRISE"
+						],
+						"example": "BUSINESS",
+						"type": "string"
+					},
+					"UserTaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"required": [
+					"Name",
+					"Email"
+				],
+				"type": "object"
+			},
+			"DNSResolver": {
+				"additionalProperties": false,
+				"properties": {
+					"CreatedBy": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"InboundIpAddresses": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The IP Addresses attached to the Inbound DNS Resolver.",
+								"example": [
+									"192.168.0.1",
+									"192.168.0.2"
+								],
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"Interfaces": {
+						"description": "The number of ENIs to attach to the DNS Resolvers.",
+						"example": 2,
+						"type": "integer"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Stax DNS Resolvers.",
+						"example": "dns",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"NetworkingHubId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"OutboundIpAddresses": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The IP Addresses attached to the Outbound DNS Resolver.",
+								"example": [
+									"192.168.0.1",
+									"192.168.0.2"
+								],
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"Status": {
+						"description": "The status of the Stax DNS Resolvers.",
+						"enum": [
+							"ACTIVE",
+							"CREATE_IN_PROGRESS",
+							"CREATE_FAILED",
+							"DELETE_IN_PROGRESS",
+							"DELETED",
+							"DELETE_FAILED",
+							"UPDATE_IN_PROGRESS"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"UserTaskId": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					}
+				},
+				"required": [
+					"Name",
+					"NetworkingHubId",
+					"Interfaces"
+				],
+				"type": "object"
+			},
+			"DNSRule": {
+				"additionalProperties": false,
+				"properties": {
+					"AwsRuleId": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The AWS Route53 Resolver Rule Id.",
+								"readOnly": true,
+								"type": "string"
+							}
+						]
+					},
+					"CreatedBy": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"DnsResolverId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"DomainName": {
+						"description": "Domain name to forward DNS queries for.",
+						"example": "test.local",
+						"maxLength": 128,
+						"minLength": 2,
+						"type": "string"
+					},
+					"ForwarderIpAddresses": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The IP Addresses to forward DNS queries to.",
+								"example": [
+									"192.168.0.1",
+									"192.168.0.2"
+								],
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of Stax DNS Rule.",
+						"example": "on-premises",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Status": {
+						"description": "The status of the Stax DNS Rule.",
+						"enum": [
+							"ACTIVE",
+							"CREATE_IN_PROGRESS",
+							"CREATE_FAILED",
+							"DELETE_IN_PROGRESS",
+							"DELETED",
+							"DELETE_FAILED",
+							"UPDATE_IN_PROGRESS"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"UserTaskId": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					}
+				},
+				"required": [
+					"Name",
+					"DomainName",
+					"DnsResolverId"
+				],
+				"type": "object"
+			},
+			"DeleteCatalogueDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"AdditionalMetaData": {
+						"properties": {
+							"CatalogueVersionId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"CreatedBy": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"CreatedTS": {
+								"description": "Created timestamp.",
+								"example": "2018-10-11T01:05:45.000Z",
+								"format": "date-time",
+								"readOnly": true,
+								"type": "string"
+							},
+							"Description": {
+								"description": "Description of the Workload.",
+								"example": "A Workload to build a VPC in my org",
+								"maxLength": 1024,
+								"type": "string"
+							},
+							"Id": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"ModifiedTS": {
+								"description": "Modified timestamp.",
+								"example": "2018-10-11T01:05:45.000Z",
+								"format": "date-time",
+								"readOnly": true,
+								"type": "string"
+							},
+							"Name": {
+								"description": "Name of the Workload Catalogue Item to create.",
+								"example": "my-directory-service",
+								"maxLength": 64,
+								"minLength": 2,
+								"type": "string"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"Protection": {
+								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+								"example": false,
+								"type": "boolean"
+							},
+							"Public": {
+								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+								"example": false,
+								"type": "boolean"
+							},
+							"Status": {
+								"description": "Status of the Workload.",
+								"enum": [
+									"NEW",
+									"UPLOADING",
+									"VALIDATING",
+									"ACTIVE",
+									"DELETED",
+									"FAILED"
+								],
+								"example": "NEW",
+								"readOnly": true,
+								"type": "string"
+							},
+							"UserTaskId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						},
+						"type": "object"
+					},
+					"TraceId": {
+						"type": "string"
+					},
+					"WorkloadCatalogueItem": {
+						"$ref": "#\/components\/schemas\/Operation"
+					}
+				},
+				"type": "object"
+			},
+			"DeleteCatalogueEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"CatalogueId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CustomerId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Detail": {
+						"$ref": "#\/components\/schemas\/DeleteCatalogueDetail"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"TraceId": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"DeletePolicyDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"Policy": {
+						"properties": {
+							"CreatedBy": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"CustomerId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OrgId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"PolicyId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TaskId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TraceId": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"DeletePolicyEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"Detail": {
+						"$ref": "#\/components\/schemas\/DeletePolicyDetail"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"DeleteVersionDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"AdditionalMetaData": {
+						"properties": {
+							"CatalogueId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"CreatedBy": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"CreatedTS": {
+								"description": "Created timestamp.",
+								"example": "2018-10-11T01:05:45.000Z",
+								"format": "date-time",
+								"readOnly": true,
+								"type": "string"
+							},
+							"Description": {
+								"description": "Description of the Workload.",
+								"example": "A Workload to build a VPC in my org",
+								"maxLength": 1024,
+								"type": "string"
+							},
+							"Id": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"ManifestURL": {
+								"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+								"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+								"type": "string"
+							},
+							"ModifiedTS": {
+								"description": "Modified timestamp.",
+								"example": "2018-10-11T01:05:45.000Z",
+								"format": "date-time",
+								"readOnly": true,
+								"type": "string"
+							},
+							"Outputs": {
+								"items": {
+									"example": "bread",
+									"type": "string"
+								},
+								"nullable": true,
+								"readOnly": true,
+								"type": "array"
+							},
+							"Public": {
+								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+								"example": false,
+								"type": "boolean"
+							},
+							"Status": {
+								"description": "Status of the Workload.",
+								"enum": [
+									"NEW",
+									"UPLOADING",
+									"VALIDATING",
+									"ACTIVE",
+									"DELETED",
+									"FAILED"
+								],
+								"example": "NEW",
+								"readOnly": true,
+								"type": "string"
+							},
+							"UserTaskId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"WorkloadCatalogueName": {
+								"description": "Name of the Workload Catalogue Item to create.",
+								"example": "my-directory-service",
+								"maxLength": 64,
+								"minLength": 2,
+								"type": "string"
+							},
+							"WorkloadVersion": {
+								"example": "0.01",
+								"readOnly": true,
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"TraceId": {
+						"type": "string"
+					},
+					"WorkloadCatalogueVersion": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"DeleteVersionEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"CatalogueId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CustomerId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Detail": {
+						"$ref": "#\/components\/schemas\/DeleteVersionDetail"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"TraceId": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"DeleteWorkloadDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"Workload": {
+						"properties": {
+							"AccountId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"CatalogueVersionId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"CreatedBy": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Name": {
+								"description": "The Workload name.",
+								"example": "my-workload-is-cool",
+								"maxLength": 64,
+								"minLength": 2,
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OrgId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"Parameters": {
+								"$ref": "#\/components\/schemas\/Parameter"
+							},
+							"Region": {
+								"description": "AWS Region the workload will be launched in",
+								"example": "us-east-1",
+								"maxLength": 32,
+								"type": "string"
+							},
+							"TaskId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"TraceId": {
+								"type": "string"
+							},
+							"WorkloadId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"DeleteWorkloadEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"Detail": {
+						"$ref": "#\/components\/schemas\/DeleteWorkloadDetail"
+					}
+				},
+				"type": "object"
+			},
+			"Error": {
+				"properties": {
+					"Cause": {
+						"type": "string"
+					},
+					"Error": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"GetTasks": {
+				"properties": {
+					"Tasks": {
+						"$ref": "#\/components\/schemas\/Task"
+					}
+				},
+				"type": "object"
+			},
+			"GitHash": {
+				"example": "f8cf81b",
+				"maxLength": 7,
+				"minLength": 7,
+				"readOnly": true,
+				"type": "string"
+			},
+			"Group": {
+				"properties": {
+					"CreatedBy": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Group.",
+						"example": "DevOps",
+						"maxLength": 128,
+						"minLength": 3,
+						"type": "string"
+					},
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Status": {
+						"description": "Status of the Group.",
+						"enum": [
+							"ACTIVE",
+							"DELETED"
+						],
+						"example": "ACTIVE",
+						"type": "string"
+					},
+					"UserTaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Users": {
+						"description": "Array of IDs of Users belonging to the Group.",
+						"items": {
+							"$ref": "#\/components\/schemas\/ro-uuidv4"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"Id",
+					"Name"
+				],
+				"type": "object"
+			},
+			"IdamUser": {
+				"properties": {
+					"id": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					}
+				},
+				"required": [
+					"id"
+				],
+				"type": "object"
+			},
+			"NetworkingHub": {
+				"additionalProperties": false,
+				"properties": {
+					"AccountId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"Asn": {
+						"description": "A private Autonomous System Number (ASN) for the Amazon side of a BGP session",
+						"example": 64512,
+						"type": "integer"
+					},
+					"CreatedBy": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Description": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "Longer description of what the Stax Networking Hub is used for.",
+								"example": "my-hub",
+								"maxLength": 512,
+								"minLength": 0,
+								"type": "string"
+							}
+						]
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"InterfaceEndpoints": {
+						"items": {
+							"$ref": "#\/components\/schemas\/interface-endpoint"
+						},
+						"type": "array"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of Stax Networking Hub.",
+						"example": "non-prod",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"PhzSuffix": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
+								"example": "my-domain.cloud",
+								"type": "string"
+							}
+						]
+					},
+					"Region": {
+						"$ref": "#\/components\/schemas\/AwsRegion"
+					},
+					"Status": {
+						"description": "The status of the Stax Networking Hub.",
+						"enum": [
+							"ACTIVE",
+							"CREATE_IN_PROGRESS",
+							"CREATE_FAILED",
+							"DELETE_IN_PROGRESS",
+							"DELETED",
+							"DELETE_FAILED",
+							"UPDATE_IN_PROGRESS"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"UserTaskId": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					}
+				},
+				"required": [
+					"Name",
+					"AccountId",
+					"Region"
+				],
+				"type": "object"
+			},
+			"Operation": {
+				"enum": [
+					"CREATE",
+					"READ",
+					"UPDATE",
+					"DELETE",
+					"accounts:CreateAccount",
+					"accounts:CreateAccountType",
+					"accounts:DiscoverAccounts",
+					"accounts:DeleteAccountType",
+					"accounts:ReadAccountTypes",
+					"accounts:ReadAccounts",
+					"accounts:UpdateAccount",
+					"accounts:UpdateAccountType",
+					"accounts:UpdateAccountTypeAccess",
+					"accounts:UpdateAccountTypeMembers",
+					"accounts:UpdatePolicies",
+					"organisations:AttachPolicy",
+					"organisations:CreatePolicy",
+					"organisations:DeletePolicy",
+					"organisations:DetachPolicy",
+					"organisations:ReadPolicies",
+					"organisations:UpdatePolicy",
+					"teams:CreateApiToken",
+					"teams:CreateGroup",
+					"teams:CreateUser",
+					"teams:DeleteApiToken",
+					"teams:DeleteGroup",
+					"teams:DeleteUser",
+					"teams:ReadApiTokens",
+					"teams:ReadGroups",
+					"teams:ReadUsers",
+					"teams:UpdateApiToken",
+					"teams:UpdateGroup",
+					"teams:UpdateGroupMembers",
+					"teams:UpdateUser",
+					"teams:UpdateUserPassword",
+					"workloads:CreateCatalogueItem",
+					"workloads:CreateCatalogueVersion",
+					"workloads:CreateWorkload",
+					"workloads:DeleteCatalogueItem",
+					"workloads:DeleteCatalogueVersion",
+					"workloads:DeleteWorkload",
+					"workloads:ReadWorkloadCatalogueItems",
+					"workloads:ReadWorkloads",
+					"workloads:UpdateWorkload",
+					"networking:CreateHub",
+					"networking:UpdateHub",
+					"networking:DeleteHub",
+					"networking:CreateVpc",
+					"networking:UpdateVpc",
+					"networking:DeleteVpc",
+					"networking:CreateDnsResolver",
+					"networking:UpdateDnsResolver",
+					"networking:DeleteDnsResolver",
+					"networking:CreateDnsRule",
+					"networking:UpdateDnsRule",
+					"networking:DeleteDnsRule"
+				],
+				"type": "string"
+			},
+			"OperationStatus": {
+				"enum": [
+					"STARTED",
+					"RUNNING",
+					"SUCCEEDED",
+					"FAILED",
+					"TIMED_OUT",
+					"ABORTED"
+				],
+				"type": "string"
+			},
+			"Organisation": {
+				"properties": {
+					"Alias": {
+						"description": "Alias for your Organisation. This alias will be used in the URL of your Stax Identity Broker.",
+						"example": "my-stax-org",
+						"maxLength": 64,
+						"minLength": 3,
+						"type": "string"
+					},
+					"AllowedDomains": {
+						"description": "Allowed email domains for the Organisation, this limits who can be invited to your Team.",
+						"example": "@example.com,@stax.io",
+						"maxLength": 64,
+						"minLength": 3,
+						"nullable": true,
+						"type": "string"
+					},
+					"AttachedPolicies": {
+						"items": {
+							"$ref": "#\/components\/schemas\/ro-uuidv4"
+						},
+						"readOnly": true,
+						"type": "array"
+					},
+					"AwsAccountEmailTemplate": {
+						"description": "AWS Accounts will be registered with email addresses fitting this pattern. Please ensure these email addresses are secured, as they can be used for Root Credential recovery.",
+						"example": "stax.user+${Stax::AccountId}@example.com",
+						"maxLength": 64,
+						"minLength": 3,
+						"nullable": true,
+						"type": "string"
+					},
+					"AwsPartnerSupport": {
+						"description": "AWS Partner Led Support - if you have partner led support then Stax Support will open AWS Support cases on your behalf.",
+						"type": "boolean"
+					},
+					"AwsSupportType": {
+						"description": "Default AWS Support level set on Accounts in your Organisation.",
+						"enum": [
+							"BASIC",
+							"DEVELOPER",
+							"BUSINESS",
+							"ENTERPRISE"
+						],
+						"example": "ENTERPRISE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"CreatedBy": {
+						"anyOf": [
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							{
+								"nullable": true
+							}
+						]
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"CustomerId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ExternalStaxId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Organisation",
+						"example": "default",
+						"maxLength": 64,
+						"minLength": 3,
+						"type": "string"
+					},
+					"Region": {
+						"$ref": "#\/components\/schemas\/AwsRegion"
+					},
+					"SpotlightSsoURL": {
+						"readOnly": true,
+						"type": "string"
+					},
+					"Status": {
+						"description": "Status of the Organisation.",
+						"enum": [
+							"NEW",
+							"INITIALIZING",
+							"ACTIVE",
+							"SUSPENDED"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"UserTaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"Pagination": {
+				"description": "Pagination metadata. Present when limit and offset parameters are supplied.",
+				"properties": {
+					"NextOffset": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "Offset value to provide to retrieve the next set of items. Null when there are no more pages to fetch.",
+								"example": 20,
+								"type": "number"
+							}
+						]
+					},
+					"PrevOffset": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "Offset value to provide to retrieve the previous set of items. Null when the first page is returned.",
+								"example": null,
+								"type": "number"
+							}
+						]
+					},
+					"Total": {
+						"description": "Total number of items in the full pagination set after filters are applied.",
+						"example": 100,
+						"type": "number"
+					}
+				},
+				"required": [
+					"Total",
+					"NextOffset",
+					"PrevOffset"
+				],
+				"type": "object"
+			},
+			"Parameter": {
+				"example": {
+					"Key": "Bread",
+					"Value": "Croissant"
+				},
+				"nullable": true,
+				"properties": {
+					"Key": {
+						"maxLength": 255,
+						"minLength": 1,
+						"type": "string"
+					},
+					"Value": {
+						"oneOf": [
+							{
+								"maxLength": 4096,
+								"minLength": 1,
+								"type": "string"
+							},
+							{
+								"type": "integer"
+							}
+						]
+					}
+				},
+				"type": "object"
+			},
+			"Policy": {
+				"properties": {
+					"AttachableTo": {
+						"description": "Whether a policy is org only or account type only, or both",
+						"enum": [
+							"ORG",
+							"ACCOUNT_TYPE",
+							"ANY"
+						],
+						"example": "ANY",
+						"readOnly": false,
+						"type": "string"
+					},
+					"CreatedBy": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Description": {
+						"description": "Description of the Policy.",
+						"example": "A service control policy that denies access to all.",
+						"maxLength": 1024,
+						"minLength": 3,
+						"type": "string"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Mandatory": {
+						"description": "Boolean value declaring if the policy is mandatory or not.",
+						"example": false,
+						"type": "boolean"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Policy.",
+						"example": "DenyAll",
+						"maxLength": 128,
+						"minLength": 3,
+						"type": "string"
+					},
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Policy": {
+						"type": "string"
+					},
+					"Public": {
+						"description": "Boolean value declaring if the policy is public or private.",
+						"example": false,
+						"type": "boolean"
+					},
+					"Status": {
+						"description": "Status of the policy.",
+						"enum": [
+							"ACTIVE",
+							"DELETED",
+							"FAILED"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"Resource": {
+				"properties": {
+					"ResourceId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ResourceType": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"Role": {
+				"description": "Stax role assigned to user.",
+				"enum": [
+					"customer_root",
+					"customer_admin",
+					"customer_user",
+					"customer_readonly"
+				],
+				"example": "customer_admin",
+				"type": "string"
+			},
+			"StaxEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"Details": {
+						"$ref": "#\/components\/schemas\/TaskEventDetail"
+					}
+				}
+			},
+			"Tags": {
+				"anyOf": [
+					{
+						"additionalProperties": {
+							"type": "string"
+						},
+						"maxProperties": 100,
+						"minProperties": 1,
+						"type": "object"
+					},
+					{
+						"nullable": true
+					}
+				],
+				"example": {
+					"CostCode": "12345"
+				}
+			},
+			"Task": {
+				"$ref": "#\/components\/schemas\/WorkloadTask"
+			},
+			"TaskEventDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				}
+			},
+			"TraceEventDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"TraceId": {
+						"type": "string"
+					}
+				}
+			},
+			"UpdateCatalogueDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"TraceId": {
+						"type": "string"
+					},
+					"WorkloadCatalogueItem": {
+						"properties": {
+							"CatalogueId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Description": {
+								"description": "Description of the Workload.",
+								"example": "A Workload to build a VPC in my org",
+								"maxLength": 1024,
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Public": {
+								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+								"example": false,
+								"type": "boolean"
+							},
+							"Version": {
+								"example": "0.01",
+								"readOnly": true,
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"UpdateCatalogueEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"CatalogueId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CustomerId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Detail": {
+						"$ref": "#\/components\/schemas\/UpdateCatalogueDetail"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"TraceId": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"UpdatePolicyDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"Policy": {
+						"properties": {
+							"CreatedBy": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"CustomerId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Name": {
+								"description": "Name of the Policy.",
+								"example": "DenyAll",
+								"maxLength": 128,
+								"minLength": 3,
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OrgId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"PolicyId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TaskId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TraceId": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"UpdatePolicyEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"Detail": {
+						"$ref": "#\/components\/schemas\/UpdatePolicyDetail"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"UpdateWorkloadDetail": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEventDetail"
+					}
+				],
+				"properties": {
+					"Workload": {
+						"properties": {
+							"AccountId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"CatalogueVersionId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"CreatedBy": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"Name": {
+								"description": "The Workload name.",
+								"example": "my-workload-is-cool",
+								"maxLength": 64,
+								"minLength": 2,
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OrgId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"OrganisationId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"Parameters": {
+								"$ref": "#\/components\/schemas\/Parameter"
+							},
+							"Region": {
+								"description": "AWS Region the workload will be launched in",
+								"example": "us-east-1",
+								"maxLength": 32,
+								"type": "string"
+							},
+							"TaskId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							},
+							"TraceId": {
+								"type": "string"
+							},
+							"WorkloadId": {
+								"$ref": "#\/components\/schemas\/uuidv4"
+							}
+						},
+						"type": "object"
+					}
+				},
+				"type": "object"
+			},
+			"UpdateWorkloadEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					}
+				],
+				"properties": {
+					"Detail": {
+						"$ref": "#\/components\/schemas\/UpdateWorkloadDetail"
+					},
+					"WorkloadId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"User": {
+				"properties": {
+					"AuthOrigin": {
+						"example": "idam",
+						"readOnly": true,
+						"type": "string"
+					},
+					"CreatedBy": {
+						"oneOf": [
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							{
+								"nullable": true
+							}
+						]
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"CustomerId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"Description": {
+						"example": "Marketing User",
+						"nullable": true,
+						"type": "string"
+					},
+					"Email": {
+						"description": "Email address of User.",
+						"example": "stax.user@example.com",
+						"format": "email",
+						"maxLength": 128,
+						"minLength": 6,
+						"readOnly": true,
+						"type": "string"
+					},
+					"FirstName": {
+						"oneOf": [
+							{
+								"description": "Given Name of the User.",
+								"example": "John",
+								"maxLength": 128,
+								"minLength": 0,
+								"type": "string"
+							},
+							{
+								"nullable": true
+							}
+						]
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"LastName": {
+						"oneOf": [
+							{
+								"description": "Family Name of the User.",
+								"example": "Doe",
+								"maxLength": 128,
+								"minLength": 0,
+								"type": "string"
+							},
+							{
+								"nullable": true
+							}
+						]
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Concatenation of first and last name. Defaults to email address if neither are present.",
+						"example": "John Doe",
+						"maxLength": 128,
+						"minLength": 3,
+						"type": "string"
+					},
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"PhoneNumber": {
+						"description": "Phone number of User in E.164 format.",
+						"example": "+61491570006",
+						"nullable": true,
+						"pattern": "^\\+[1-9]\\d{4,14}$",
+						"type": "string"
+					},
+					"Role": {
+						"$ref": "#\/components\/schemas\/Role"
+					},
+					"Status": {
+						"description": "Status of the User.",
+						"enum": [
+							"ACTIVE",
+							"DISABLED",
+							"DELETED",
+							"INVITED",
+							"NEW"
+						],
+						"example": "ACTIVE",
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"UserTaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"required": [
+					"Id",
+					"Email",
+					"Name",
+					"OrganisationId"
+				],
+				"type": "object"
+			},
+			"UserGroupMemberMap": {
+				"additionalProperties": false,
+				"properties": {
+					"GroupId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"UserId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					}
+				},
+				"type": "object"
+			},
+			"UserTask": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseTask"
+					}
+				],
+				"properties": {
+					"Users": {
+						"items": {
+							"$ref": "#\/components\/schemas\/ro-uuidv4"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"VPC": {
+				"additionalProperties": false,
+				"properties": {
+					"AccountId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"AwsVpcId": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The AWS VPC ID.",
+								"readOnly": true,
+								"type": "string"
+							}
+						]
+					},
+					"Cidr": {
+						"description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
+						"example": "10.128.0.0\/23",
+						"type": "string"
+					},
+					"CidrRangeId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"CreateIgw": {
+						"description": "Boolean value declaring if Internet Gateway is enabled",
+						"example": true,
+						"type": "boolean"
+					},
+					"CreateNat": {
+						"description": "Boolean value declaring if NAT Gateways is enabled",
+						"example": true,
+						"type": "boolean"
+					},
+					"CreatedBy": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Description": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "Longer description of what the Stax VPC is used for.",
+								"example": "VPC for my particular application",
+								"maxLength": 2048,
+								"minLength": 0,
+								"type": "string"
+							}
+						]
+					},
+					"GatewayEndpoints": {
+						"items": {
+							"$ref": "#\/components\/schemas\/gateway-endpoint"
+						},
+						"type": "array"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of Stax VPC",
+						"example": "non-prod",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"NetworkingHubId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"PhzId": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The Route53 Private Hosted Zone Id for the VPC",
+								"example": "PHZAAEXAMPLE",
+								"type": "string"
+							}
+						]
+					},
+					"PhzPrefix": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
+								"example": "dev",
+								"type": "string"
+							}
+						]
+					},
+					"RedundantNat": {
+						"description": "Boolean value declaring if redundant NAT Gateways will be created",
+						"example": false,
+						"type": "boolean"
+					},
+					"Region": {
+						"$ref": "#\/components\/schemas\/AwsRegion"
+					},
+					"Size": {
+						"description": "Size of the VPC.",
+						"enum": [
+							"SMALL",
+							"MEDIUM",
+							"LARGE"
+						],
+						"example": "SMALL",
+						"type": "string"
+					},
+					"Status": {
+						"description": "The status of the Stax VPC.",
+						"enum": [
+							"ACTIVE",
+							"CREATE_IN_PROGRESS",
+							"CREATE_FAILED",
+							"DELETE_IN_PROGRESS",
+							"DELETED",
+							"DELETE_FAILED",
+							"UPDATE_IN_PROGRESS"
+						],
+						"example": "ACTIVE",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"Type": {
+						"description": "Type of VPC. The Type determines what Route Tables are attached to the VPC",
+						"enum": [
+							"FLAT",
+							"ISOLATED",
+							"SHAREDSERVICES",
+							"TRANSIT"
+						],
+						"example": "FLAT",
+						"type": "string"
+					},
+					"UserTaskId": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						]
+					},
+					"Zone": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "All 'Flat' VPCs in the same Zone can communicate to each other.",
+								"example": "non-prod",
+								"maxLength": 32,
+								"minLength": 2,
+								"type": "string"
+							}
+						]
+					}
+				},
+				"required": [
+					"Name",
+					"AccountId",
+					"Region"
+				],
+				"type": "object"
+			},
+			"Workload": {
+				"properties": {
+					"AccountId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"CatalogueId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"CatalogueVersionId": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"$ref": "#\/components\/schemas\/uuidv4"
+							}
+						]
+					},
+					"CreatedBy": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "The Workload name.",
+						"example": "my-workload-is-cool",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"Parameters": {
+						"$ref": "#\/components\/schemas\/Parameter"
+					},
+					"Protection": {
+						"description": "Boolean value declaring if the Workload is protected from deletion",
+						"example": false,
+						"type": "boolean"
+					},
+					"Region": {
+						"description": "AWS Region the workload will be launched in",
+						"example": "us-east-1",
+						"maxLength": 32,
+						"type": "string"
+					},
+					"Status": {
+						"description": "Status of the Workload.",
+						"enum": [
+							"NEW",
+							"INITIALIZING",
+							"ACTIVE",
+							"CREATE_FAILED",
+							"DELETE_IN_PROGRESS",
+							"DELETED",
+							"DELETE_FAILED",
+							"UPDATE_IN_PROGRESS",
+							"UPDATE_FAILED",
+							"UPDATE_COMPLETE"
+						],
+						"example": "NEW",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"UserTaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					}
+				},
+				"required": [
+					"Name",
+					"CatalogueId",
+					"AccountId",
+					"Region"
+				],
+				"type": "object"
+			},
+			"WorkloadCatalogue": {
+				"properties": {
+					"CatalogueVersionId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CreatedBy": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Description": {
+						"description": "Description of the Workload.",
+						"example": "A Workload to build a VPC in my org",
+						"maxLength": 1024,
+						"type": "string"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Workload Catalogue Item to create.",
+						"example": "my-directory-service",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"Protection": {
+						"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+						"example": false,
+						"type": "boolean"
+					},
+					"Public": {
+						"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+						"example": false,
+						"type": "boolean"
+					},
+					"Status": {
+						"description": "Status of the Workload.",
+						"enum": [
+							"NEW",
+							"UPLOADING",
+							"VALIDATING",
+							"ACTIVE",
+							"DELETED",
+							"FAILED"
+						],
+						"example": "NEW",
+						"readOnly": true,
+						"type": "string"
+					},
+					"UserTaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Versions": {
+						"items": {
+							"$ref": "#\/components\/schemas\/WorkloadCatalogueVersion"
+						},
+						"readOnly": true,
+						"type": "array"
+					}
+				},
+				"required": [
+					"Id",
+					"Versions"
+				]
+			},
+			"WorkloadCatalogueVersion": {
+				"properties": {
+					"CatalogueId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CreatedBy": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"CreatedTS": {
+						"description": "Created timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Description": {
+						"description": "Description of the Workload.",
+						"example": "A Workload to build a VPC in my org",
+						"maxLength": 1024,
+						"type": "string"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"ManifestURL": {
+						"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+						"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+						"type": "string"
+					},
+					"ModifiedTS": {
+						"description": "Modified timestamp.",
+						"example": "2018-10-11T01:05:45.000Z",
+						"format": "date-time",
+						"readOnly": true,
+						"type": "string"
+					},
+					"Outputs": {
+						"items": {
+							"example": "bread",
+							"type": "string"
+						},
+						"nullable": true,
+						"readOnly": true,
+						"type": "array"
+					},
+					"Parameters": {
+						"items": {
+							"$ref": "#\/components\/schemas\/Parameter"
+						},
+						"type": "array"
+					},
+					"Public": {
+						"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+						"example": false,
+						"type": "boolean"
+					},
+					"Status": {
+						"description": "Status of the Workload.",
+						"enum": [
+							"NEW",
+							"UPLOADING",
+							"VALIDATING",
+							"ACTIVE",
+							"DELETED",
+							"FAILED"
+						],
+						"example": "NEW",
+						"readOnly": true,
+						"type": "string"
+					},
+					"UserTaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"WorkloadVersion": {
+						"example": "0.01",
+						"readOnly": true,
+						"type": "string"
+					}
+				},
+				"required": [
+					"Id",
+					"Status",
+					"ManifestURL",
+					"WorkloadVersion"
+				],
+				"type": "object"
+			},
+			"WorkloadTask": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseTask"
+					}
+				],
+				"properties": {
+					"Workloads": {
+						"items": {
+							"$ref": "#\/components\/schemas\/ro-uuidv4"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"accounts.CreateAccount": {
+				"properties": {
+					"AccountType": {
+						"type": "string"
+					},
+					"AwsAccountId": {
+						"description": "AWS Account Id.",
+						"example": "012345678901",
+						"maxLength": 12,
+						"minLength": 12,
+						"readOnly": true,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Account.",
+						"example": "bakery",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name",
+					"AccountType"
+				],
+				"type": "object"
+			},
+			"accounts.CreateAccountType": {
+				"properties": {
+					"Name": {
+						"description": "Name of the Account Type.",
+						"example": "Development",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					}
+				},
+				"required": [
+					"Name"
+				],
+				"type": "object"
+			},
+			"accounts.CreateAccountTypeResponse": {
+				"properties": {
+					"Detail": {
+						"properties": {
+							"AccountType": {
+								"properties": {
+									"Accounts": {
+										"example": [],
+										"type": "array"
+									},
+									"CreatedBy": {
+										"$ref": "#\/components\/schemas\/ro-uuidv4"
+									},
+									"CreatedTS": {
+										"description": "Created timestamp.",
+										"example": "2018-10-11T01:05:45.000Z",
+										"format": "date-time",
+										"nullable": true,
+										"readOnly": true,
+										"type": "string"
+									},
+									"Id": {
+										"$ref": "#\/components\/schemas\/ro-uuidv4"
+									},
+									"ModifiedTS": {
+										"description": "Modified timestamp.",
+										"example": "2018-10-11T01:05:45.000Z",
+										"format": "date-time",
+										"nullable": true,
+										"readOnly": true,
+										"type": "string"
+									},
+									"Name": {
+										"example": "Development",
+										"type": "string"
+									},
+									"OrganisationId": {
+										"$ref": "#\/components\/schemas\/ro-uuidv4"
+									},
+									"Policies": {
+										"example": [],
+										"type": "array"
+									},
+									"Roles": {
+										"example": [],
+										"type": "array"
+									},
+									"Status": {
+										"enum": [
+											"ACTIVE",
+											"DELETED"
+										],
+										"example": "ACTIVE"
+									},
+									"StaxCreated": {
+										"type": "boolean"
+									}
+								},
+								"type": "object"
+							},
+							"Message": {
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OperationStatus": {
+								"$ref": "#\/components\/schemas\/OperationStatus"
+							},
+							"Severity": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"DetailType": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"Detail",
+					"DetailType"
+				],
+				"type": "object"
+			},
+			"accounts.DiscoverAccounts": {
+				"type": "object"
+			},
+			"accounts.DiscoverAccountsResponse": {
+				"allOf": [
+					{
+						"properties": {
+							"CustomerId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TaskId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TraceId": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					},
+					{
+						"properties": {
+							"Detail": {
+								"$ref": "#\/components\/schemas\/TraceEventDetail"
+							}
+						}
+					}
+				]
+			},
+			"accounts.OnboardAccount": {
+				"properties": {
+					"AccountType": {
+						"anyOf": [
+							{
+								"example": "Development",
+								"type": "string"
+							},
+							{
+								"$ref": "#\/components\/schemas\/uuidv4"
+							}
+						]
+					},
+					"AwsAccountId": {
+						"description": "AWS Account Id.",
+						"example": "012345678901",
+						"maxLength": 12,
+						"minLength": 12,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Account.",
+						"example": "bakery",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"AwsAccountId",
+					"AccountType"
+				],
+				"type": "object"
+			},
+			"accounts.ReadAccountTypes": {
+				"properties": {
+					"AccountTypes": {
+						"items": {
+							"$ref": "#\/components\/schemas\/AccountType"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"accounts.ReadAccounts": {
+				"properties": {
+					"Accounts": {
+						"items": {
+							"$ref": "#\/components\/schemas\/Account"
+						},
+						"type": "array"
+					},
+					"Paging": {
+						"$ref": "#\/components\/schemas\/Pagination"
+					}
+				},
+				"required": [
+					"Accounts"
+				],
+				"type": "object"
+			},
+			"accounts.UpdateAccount": {
+				"properties": {
+					"AccountType": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"Name": {
+						"description": "Name of the Account.",
+						"example": "bakery",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"type": "object"
+			},
+			"accounts.UpdateAccountResponse": {
+				"properties": {
+					"CustomerId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Detail": {
+						"properties": {
+							"Account": {
+								"properties": {
+									"AccountName": {
+										"example": "automation",
+										"type": "string"
+									},
+									"AccountType": {
+										"$ref": "#\/components\/schemas\/ro-uuidv4"
+									},
+									"Name": {
+										"example": "automation",
+										"type": "string"
+									},
+									"Operation": {
+										"$ref": "#\/components\/schemas\/Operation"
+									},
+									"OrganisationId": {
+										"$ref": "#\/components\/schemas\/ro-uuidv4"
+									},
+									"Tags": {
+										"$ref": "#\/components\/schemas\/Tags"
+									}
+								},
+								"type": "object"
+							},
+							"Message": {
+								"type": "string"
+							},
+							"Operation": {
+								"$ref": "#\/components\/schemas\/Operation"
+							},
+							"OperationStatus": {
+								"$ref": "#\/components\/schemas\/OperationStatus"
+							},
+							"Severity": {
+								"type": "string"
+							},
+							"TraceId": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					"DetailType": {
+						"type": "string"
+					},
+					"TaskId": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"TraceId": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"Detail",
+					"DetailType"
+				],
+				"type": "object"
+			},
+			"accounts.UpdateAccountType": {
+				"properties": {
+					"Name": {
+						"description": "Name of the Account Type.",
+						"example": "Development",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"accounts.UpdateAccountTypeAccess": {
+				"properties": {
+					"AddRoles": {
+						"example": [
+							{
+								"AccountTypeId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+								"GroupId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+								"RoleName": "admin"
+							}
+						],
+						"items": {
+							"$ref": "#\/components\/schemas\/AccountTypeAccessMap"
+						},
+						"type": "array"
+					},
+					"RemoveRoles": {
+						"example": [],
+						"items": {
+							"$ref": "#\/components\/schemas\/AccountTypeAccessMap"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"accounts.UpdateAccountTypeMembers": {
+				"properties": {
+					"Members": {
+						"example": [
+							{
+								"AccountId": "B4407766-E821-450D-B7C8-9EA38B58C432",
+								"AccountTypeId": "B4407766-E821-450D-B7C8-9EA38B58C432"
+							}
+						],
+						"items": {
+							"$ref": "#\/components\/schemas\/AccountTypeMemberMap"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"accounts.UpdatePolicies": {
+				"properties": {
+					"AddPolicies": {
+						"example": [
+							{
+								"AccountTypeId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+								"PolicyId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc"
+							}
+						],
+						"items": {
+							"$ref": "#\/components\/schemas\/AccountTypePolicyMap"
+						},
+						"type": "array"
+					},
+					"RemovePolicies": {
+						"example": [],
+						"items": {
+							"$ref": "#\/components\/schemas\/AccountTypePolicyMap"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"gateway-endpoint": {
+				"description": "A list of gateway vpc endpoints",
+				"enum": [
+					"dynamodb",
+					"s3"
+				],
+				"example": "s3",
+				"type": "string"
+			},
+			"interface-endpoint": {
+				"description": "A list of interface vpc endpoints",
+				"enum": [
+					"access-analyzer",
+					"application-autoscaling",
+					"appmesh-envoy-management",
+					"appstream.api",
+					"appstream.streaming",
+					"athena",
+					"autoscaling",
+					"autoscaling-plans",
+					"awsconnector",
+					"clouddirectory",
+					"cloudformation",
+					"cloudtrail",
+					"codebuild",
+					"codecommit",
+					"codepipeline",
+					"config",
+					"datasync",
+					"ec2",
+					"ec2messages",
+					"ecr.api",
+					"ecr.dkr",
+					"ecs",
+					"ecs-agent",
+					"ecs-telemetry",
+					"elasticfilesystem",
+					"elasticfilesystem-fips",
+					"elasticloadbalancing",
+					"events",
+					"execute-api",
+					"git-codecommit",
+					"glue",
+					"kinesis-firehose",
+					"kinesis-streams",
+					"kms",
+					"logs",
+					"monitoring",
+					"notebook",
+					"qldb.session",
+					"rekognition",
+					"sagemaker.api",
+					"sagemaker.runtime",
+					"secretsmanager",
+					"servicecatalog",
+					"sms",
+					"sns",
+					"sqs",
+					"ssm",
+					"ssmmessages",
+					"storagegateway",
+					"sts",
+					"transfer",
+					"transfer.server",
+					"workspaces"
+				],
+				"example": "ec2",
+				"type": "string"
+			},
+			"networking.CreateCidrExclusion": {
+				"additionalProperties": false,
+				"properties": {
+					"Cidr": {
+						"description": "CIDR Range in quad dot notation.",
+						"example": "10.128.0.0\/19",
+						"type": "string"
+					},
+					"Description": {
+						"description": "Longer description of what the CIDR Exclusion is used for.",
+						"example": "This Reservation blocks out existing legacy VPCs",
+						"maxLength": 2048,
+						"minLength": 0,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the CIDR Exclusion.",
+						"example": "legacy-vpcs",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name",
+					"Cidr"
+				],
+				"type": "object"
+			},
+			"networking.CreateCidrRange": {
+				"additionalProperties": false,
+				"properties": {
+					"Cidr": {
+						"description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
+						"example": "10.128.0.0\/23",
+						"type": "string"
+					},
+					"Description": {
+						"description": "Longer description of what the CIDR Range is used for.",
+						"example": "CIDR Range used for team ABCD application 1234",
+						"maxLength": 2048,
+						"minLength": 0,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the CIDR Range.",
+						"example": "prod",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name",
+					"Cidr"
+				],
+				"type": "object"
+			},
+			"networking.CreateDnsResolver": {
+				"additionalProperties": false,
+				"properties": {
+					"Name": {
+						"description": "Name of Stax DNS Resolver.",
+						"example": "dns",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"NumberOfInterfaces": {
+						"description": "The number of ENIs to attach to the Stax DNS Resolvers.",
+						"example": 2,
+						"type": "integer"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name",
+					"NumberOfInterfaces"
+				],
+				"type": "object"
+			},
+			"networking.CreateDnsRule": {
+				"additionalProperties": false,
+				"properties": {
+					"DomainName": {
+						"description": "Domain name to forward DNS queries for.",
+						"example": "test.local",
+						"maxLength": 128,
+						"minLength": 2,
+						"type": "string"
+					},
+					"ForwarderIpAddresses": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The IP Addresses to forward DNS queries to.",
+								"example": [
+									"192.168.0.1",
+									"192.168.0.2"
+								],
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"Name": {
+						"description": "Name of Stax DNS Rule.",
+						"example": "on-premises",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name",
+					"DomainName"
+				],
+				"type": "object"
+			},
+			"networking.CreateHub": {
+				"additionalProperties": false,
+				"properties": {
+					"AccountId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"AmazonSideAsn": {
+						"description": "A private Autonomous System Number (ASN) for the Amazon side of a BGP session",
+						"example": 64512,
+						"maximum": 65534,
+						"minimum": 64512,
+						"type": "integer"
+					},
+					"Cidr": {
+						"description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/22 for the Transit VPC",
+						"example": "10.128.0.0\/22",
+						"type": "string"
+					},
+					"CidrExclusions": {
+						"items": {
+							"$ref": "#\/components\/schemas\/CidrExclusion"
+						},
+						"type": "array"
+					},
+					"CidrRangeName": {
+						"description": "Name of the CIDR Range where the Transit VPC lives.",
+						"example": "myrange",
+						"maxLength": 64,
+						"minLength": 0,
+						"type": "string"
+					},
+					"CreateInternetGateway": {
+						"description": "Boolean value declaring to create an Internet Gateway",
+						"example": true,
+						"type": "boolean"
+					},
+					"CreateNatGateway": {
+						"description": "Boolean value declaring to create NAT Gateways",
+						"example": true,
+						"type": "boolean"
+					},
+					"Description": {
+						"description": "Longer description of what the Stax Networking Hub is used for.",
+						"example": "This Hub is for a team ABCD applications",
+						"maxLength": 2048,
+						"minLength": 0,
+						"type": "string"
+					},
+					"GatewayEndpoints": {
+						"items": {
+							"$ref": "#\/components\/schemas\/gateway-endpoint"
+						},
+						"type": "array"
+					},
+					"InterfaceEndpoints": {
+						"items": {
+							"$ref": "#\/components\/schemas\/interface-endpoint"
+						},
+						"type": "array"
+					},
+					"Name": {
+						"description": "Name of Stax Networking Hub.",
+						"example": "prod",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"PhzSuffix": {
+						"description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
+						"example": "my-domain.cloud",
+						"type": "string"
+					},
+					"Region": {
+						"$ref": "#\/components\/schemas\/AwsRegion"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name",
+					"AccountId",
+					"Region",
+					"Cidr",
+					"CreateNatGateway",
+					"CreateInternetGateway"
+				],
+				"type": "object"
+			},
+			"networking.CreateVpc": {
+				"additionalProperties": false,
+				"properties": {
+					"AccountId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"CidrRangeId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"CreateInternetGateway": {
+						"description": "Boolean value declaring to create an Internet Gateway",
+						"example": true,
+						"type": "boolean"
+					},
+					"Description": {
+						"description": "Longer description of what the Stax VPC is used for.",
+						"example": "VPC for a non-prod microservice",
+						"maxLength": 2048,
+						"minLength": 0,
+						"type": "string"
+					},
+					"GatewayEndpoints": {
+						"items": {
+							"$ref": "#\/components\/schemas\/gateway-endpoint"
+						},
+						"type": "array"
+					},
+					"Name": {
+						"description": "Name of Stax VPC",
+						"example": "dev-ms-customers",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"PhzPrefix": {
+						"description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
+						"example": "dev",
+						"type": "string"
+					},
+					"Region": {
+						"$ref": "#\/components\/schemas\/AwsRegion"
+					},
+					"Size": {
+						"description": "Size of the VPC.",
+						"enum": [
+							"SMALL",
+							"MEDIUM",
+							"LARGE"
+						],
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"Type": {
+						"description": "Type of VPC. The Type determines what Route Tables are attached to the VPC",
+						"enum": [
+							"ISOLATED",
+							"FLAT",
+							"SHAREDSERVICES"
+						],
+						"type": "string"
+					},
+					"Zone": {
+						"description": "All 'Flat' VPCs in the same Zone can communicate to each other.",
+						"example": "my-zone",
+						"maxLength": 64,
+						"minLength": 0,
+						"type": "string"
+					}
+				},
+				"required": [
+					"Name",
+					"CidrRangeId",
+					"AccountId",
+					"Region",
+					"Size",
+					"Type",
+					"CreateInternetGateway"
+				],
+				"type": "object"
+			},
+			"networking.ReadCidrExclusions": {
+				"additionalProperties": false,
+				"properties": {
+					"Exclusions": {
+						"items": {
+							"$ref": "#\/components\/schemas\/CidrExclusion"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"Exclusions"
+				],
+				"type": "object"
+			},
+			"networking.ReadCidrRanges": {
+				"additionalProperties": false,
+				"properties": {
+					"Ranges": {
+						"items": {
+							"$ref": "#\/components\/schemas\/CidrRange"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"Ranges"
+				],
+				"type": "object"
+			},
+			"networking.ReadDnsResolvers": {
+				"additionalProperties": false,
+				"properties": {
+					"DnsResolvers": {
+						"items": {
+							"$ref": "#\/components\/schemas\/DNSResolver"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"DnsResolvers"
+				],
+				"type": "object"
+			},
+			"networking.ReadDnsRules": {
+				"additionalProperties": false,
+				"properties": {
+					"DnsRules": {
+						"items": {
+							"$ref": "#\/components\/schemas\/DNSRule"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"DnsRules"
+				],
+				"type": "object"
+			},
+			"networking.ReadHubs": {
+				"additionalProperties": false,
+				"properties": {
+					"Hubs": {
+						"items": {
+							"$ref": "#\/components\/schemas\/NetworkingHub"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"Hubs"
+				],
+				"type": "object"
+			},
+			"networking.ReadVpcs": {
+				"additionalProperties": false,
+				"properties": {
+					"Vpcs": {
+						"items": {
+							"$ref": "#\/components\/schemas\/VPC"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"Vpcs"
+				],
+				"type": "object"
+			},
+			"networking.UpdateCidrExclusion": {
+				"additionalProperties": false,
+				"properties": {
+					"Description": {
+						"description": "Longer description of what the CIDR Exclusion is used for.",
+						"maxLength": 2048,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the CIDR Exclusion.",
+						"example": "data-center",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"type": "object"
+			},
+			"networking.UpdateCidrRange": {
+				"additionalProperties": false,
+				"properties": {
+					"Description": {
+						"description": "Longer description of what the CIDR Range is used for.",
+						"example": "CIDR Range used for team ABCD application 1234",
+						"maxLength": 2048,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the CIDR Range.",
+						"example": "prod",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"type": "object"
+			},
+			"networking.UpdateDnsResolver": {
+				"additionalProperties": false,
+				"properties": {
+					"Name": {
+						"description": "Name of Stax DNS Resolver.",
+						"example": "dns",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"NumberOfInterfaces": {
+						"description": "The number of ENIs to attach to the DNS Resolvers.",
+						"example": 2,
+						"type": "integer"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"type": "object"
+			},
+			"networking.UpdateDnsRule": {
+				"additionalProperties": false,
+				"properties": {
+					"ForwarderIpAddresses": {
+						"anyOf": [
+							{
+								"nullable": true
+							},
+							{
+								"description": "The IP Addresses to forward DNS queries to.",
+								"example": [
+									"192.168.0.1",
+									"192.168.0.2"
+								],
+								"items": {
+									"type": "string"
+								},
+								"type": "array"
+							}
+						]
+					},
+					"Name": {
+						"description": "Name of Stax DNS Rule.",
+						"example": "on-premises",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"type": "object"
+			},
+			"networking.UpdateHub": {
+				"additionalProperties": false,
+				"properties": {
+					"CreateInternetGateway": {
+						"description": "Boolean value declaring to create an Internet Gateway",
+						"example": true,
+						"type": "boolean"
+					},
+					"CreateNatGateway": {
+						"description": "Boolean value declaring to create NAT Gateways",
+						"example": true,
+						"type": "boolean"
+					},
+					"Description": {
+						"description": "Longer description of what the Stax Networking Hub is used for.",
+						"example": "This Hub is for connectivity from headquaters to VPC workloads",
+						"maxLength": 2048,
+						"type": "string"
+					},
+					"InterfaceEndpoints": {
+						"items": {
+							"$ref": "#\/components\/schemas\/interface-endpoint"
+						},
+						"type": "array"
+					},
+					"Name": {
+						"description": "Name of Stax Networking Hub",
+						"example": "prod",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"PhzSuffix": {
+						"description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
+						"example": "my-domain.cloud",
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"type": "object"
+			},
+			"networking.UpdateVpc": {
+				"additionalProperties": false,
+				"properties": {
+					"CreateInternetGateway": {
+						"description": "Boolean value declaring to create an Internet Gateway",
+						"example": true,
+						"type": "boolean"
+					},
+					"Description": {
+						"description": "Longer description of what this VPC is used for.",
+						"maxLength": 2048,
+						"type": "string"
+					},
+					"GatewayEndpoints": {
+						"items": {
+							"$ref": "#\/components\/schemas\/gateway-endpoint"
+						},
+						"type": "array"
+					},
+					"Name": {
+						"description": "Name of the Stax VPC",
+						"example": "prod",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"PhzPrefix": {
+						"description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
+						"example": "dev",
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"type": "object"
+			},
+			"organisations.AttachPolicy": {
+				"properties": {
+					"PolicyId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					}
+				},
+				"required": [
+					"PolicyId"
+				],
+				"type": "object"
+			},
+			"organisations.CreatePolicy": {
+				"properties": {
+					"Description": {
+						"description": "Description of the Policy.",
+						"example": "A service control policy that denies access to all.",
+						"maxLength": 1024,
+						"minLength": 3,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Policy.",
+						"example": "DenyAll",
+						"maxLength": 128,
+						"minLength": 3,
+						"type": "string"
+					},
+					"Policy": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"Name",
+					"Description",
+					"Policy"
+				],
+				"type": "object"
+			},
+			"organisations.ReadOrganisations": {
+				"properties": {
+					"Organisations": {
+						"items": {
+							"$ref": "#\/components\/schemas\/Organisation"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"organisations.ReadPolicies": {
+				"properties": {
+					"Policies": {
+						"items": {
+							"$ref": "#\/components\/schemas\/Policy"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"organisations.UpdatePolicy": {
+				"properties": {
+					"Description": {
+						"description": "Description of the Policy.",
+						"example": "A service control policy that denies access to all.",
+						"maxLength": 1024,
+						"minLength": 3,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Policy.",
+						"example": "DenyAll",
+						"maxLength": 128,
+						"minLength": 3,
+						"type": "string"
+					},
+					"Policy": {
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"ro-uuidv4": {
+				"example": "e893d7e0-9306-11e9-bc42-526af7764f64",
+				"pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+				"readOnly": true,
+				"type": "string"
+			},
+			"teams.CreateApiToken": {
+				"additionalProperties": false,
+				"properties": {
+					"Description": {
+						"description": "Longer description of what this Token is used for.",
+						"example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
+						"maxLength": 1024,
+						"minLength": 0,
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of API Token",
+						"example": "gitlab-cicd",
+						"maxLength": 64,
+						"minLength": 2,
+						"pattern": "^([0-9a-zA-Z_.-]+)$",
+						"type": "string"
+					},
+					"Role": {
+						"$ref": "#\/components\/schemas\/ApiRole"
+					},
+					"StoreToken": {
+						"default": true,
+						"description": "Store the Access and Secret key in SSM, in your security account.",
+						"example": true,
+						"type": "boolean"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"TokenKeyId": {
+						"default": "alias\/stax-api-tokens",
+						"description": "If you choose to store your keys in SSM, encrypt them with this KMS Key",
+						"example": "alias\/my-custom-key",
+						"maxLength": 128,
+						"minLength": 7,
+						"pattern": "^([a-zA-Z0-9:\/_-]+)$",
+						"type": "string"
+					}
+				},
+				"required": [
+					"Name",
+					"Role"
+				],
+				"type": "object"
+			},
+			"teams.CreateApiTokenResponse": {
+				"properties": {
+					"ApiTokens": {
+						"items": {
+							"properties": {
+								"AccessKey": {
+									"$ref": "#\/components\/schemas\/ro-uuidv4"
+								},
+								"CreatedBy": {
+									"$ref": "#\/components\/schemas\/ro-uuidv4"
+								},
+								"CreatedTS": {
+									"description": "Created timestamp.",
+									"example": "2018-10-11T01:05:45.000Z",
+									"format": "date-time",
+									"readOnly": true,
+									"type": "string"
+								},
+								"Description": {
+									"description": "Longer description of what this Token is used for.",
+									"example": "This token is for deployment pipelines in Gitlab to deploy to dev environments",
+									"maxLength": 1024,
+									"type": "string"
+								},
+								"Name": {
+									"description": "Name of API Token",
+									"example": "gitlab-cicd",
+									"maxLength": 64,
+									"minLength": 2,
+									"pattern": "^([0-9a-zA-Z_.-]+)$",
+									"type": "string"
+								},
+								"Role": {
+									"$ref": "#\/components\/schemas\/ApiRole"
+								},
+								"SecretKey": {
+									"maxLength": 32,
+									"minLength": 32,
+									"type": "string"
+								},
+								"Tags": {
+									"$ref": "#\/components\/schemas\/Tags"
+								}
+							},
+							"required": [
+								"AccessKey",
+								"SecretKey"
+							],
+							"type": "object"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"teams.CreateGroup": {
+				"properties": {
+					"Name": {
+						"description": "Name of User Group",
+						"example": "devops",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name"
+				],
+				"type": "object"
+			},
+			"teams.CreateGroupResponse": {
+				"allOf": [
+					{
+						"properties": {
+							"GroupId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							}
+						},
+						"type": "object"
+					},
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					},
+					{
+						"properties": {
+							"Detail": {
+								"$ref": "#\/components\/schemas\/TraceEventDetail"
+							}
+						}
+					}
+				]
+			},
+			"teams.CreateUser": {
+				"properties": {
+					"Email": {
+						"description": "Email address of User.",
+						"example": "stax.user@example.com",
+						"format": "email",
+						"maxLength": 128,
+						"minLength": 6,
+						"type": "string"
+					},
+					"FirstName": {
+						"description": "Given Name of the User.",
+						"example": "John",
+						"maxLength": 128,
+						"minLength": 0,
+						"type": "string"
+					},
+					"LastName": {
+						"description": "Family Name of the User.",
+						"example": "Doe",
+						"maxLength": 128,
+						"minLength": 0,
+						"type": "string"
+					},
+					"PhoneNumber": {
+						"description": "Phone number of User in E.164 format.",
+						"example": "+61491570006",
+						"pattern": "^\\+[1-9]\\d{4,14}$",
+						"type": "string"
+					},
+					"Role": {
+						"$ref": "#\/components\/schemas\/Role"
+					}
+				},
+				"required": [
+					"Email",
+					"FirstName",
+					"LastName"
+				],
+				"type": "object"
+			},
+			"teams.CreateUserResponse": {
+				"allOf": [
+					{
+						"properties": {
+							"CustomerId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TaskId": {
+								"$ref": "#\/components\/schemas\/ro-uuidv4"
+							},
+							"TraceId": {
+								"type": "string"
+							}
+						},
+						"type": "object"
+					},
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					},
+					{
+						"properties": {
+							"Detail": {
+								"$ref": "#\/components\/schemas\/TraceEventDetail"
+							}
+						}
+					}
+				]
+			},
+			"teams.InviteRootUser": {
+				"properties": {
+					"Email": {
+						"description": "Email address of User.",
+						"example": "stax.user@example.com",
+						"format": "email",
+						"maxLength": 128,
+						"minLength": 6,
+						"type": "string"
+					}
+				},
+				"required": [
+					"Email"
+				],
+				"type": "object"
+			},
+			"teams.ReadApiTokens": {
+				"properties": {
+					"ApiTokens": {
+						"items": {
+							"properties": {
+								"AccessKey": {
+									"$ref": "#\/components\/schemas\/ro-uuidv4"
+								},
+								"CreatedBy": {
+									"$ref": "#\/components\/schemas\/ro-uuidv4"
+								},
+								"CreatedTS": {
+									"description": "Created timestamp.",
+									"example": "2018-10-11T01:05:45.000Z",
+									"format": "date-time",
+									"readOnly": true,
+									"type": "string"
+								},
+								"Description": {
+									"description": "Longer description of what this Token is used for.",
+									"example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
+									"maxLength": 1024,
+									"minLength": 0,
+									"type": "string"
+								},
+								"ModifiedTS": {
+									"description": "Modified timestamp.",
+									"example": "2018-10-11T01:05:45.000Z",
+									"format": "date-time",
+									"readOnly": true,
+									"type": "string"
+								},
+								"Name": {
+									"description": "Name of API Token",
+									"example": "gitlab-cicd",
+									"maxLength": 64,
+									"minLength": 2,
+									"pattern": "^([0-9a-zA-Z_.-]+)$",
+									"type": "string"
+								},
+								"Role": {
+									"$ref": "#\/components\/schemas\/ApiRole"
+								},
+								"Status": {
+									"description": "Status of the Token.",
+									"enum": [
+										"ACTIVE",
+										"DELETED"
+									],
+									"example": "ACTIVE",
+									"type": "string"
+								},
+								"Tags": {
+									"$ref": "#\/components\/schemas\/Tags"
+								}
+							},
+							"type": "object"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"teams.ReadGroups": {
+				"properties": {
+					"Groups": {
+						"items": {
+							"$ref": "#\/components\/schemas\/Group"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"teams.ReadUsers": {
+				"properties": {
+					"Users": {
+						"items": {
+							"$ref": "#\/components\/schemas\/User"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"teams.UpdateApiToken": {
+				"properties": {
+					"Description": {
+						"description": "Longer description of what this Token is used for.",
+						"example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
+						"maxLength": 1024,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Role": {
+						"$ref": "#\/components\/schemas\/ApiRole"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"type": "object"
+			},
+			"teams.UpdateApiTokenResponse": {
+				"properties": {
+					"ApiTokens": {
+						"items": {
+							"properties": {
+								"AccessKey": {
+									"$ref": "#\/components\/schemas\/ro-uuidv4"
+								},
+								"CreatedBy": {
+									"$ref": "#\/components\/schemas\/ro-uuidv4"
+								},
+								"CreatedTS": {
+									"description": "Created timestamp.",
+									"example": "2018-10-11T01:05:45.000Z",
+									"format": "date-time",
+									"readOnly": true,
+									"type": "string"
+								},
+								"Description": {
+									"description": "Longer description of what this Token is used for.",
+									"example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
+									"maxLength": 1024,
+									"minLength": 0,
+									"type": "string"
+								},
+								"ModifiedTS": {
+									"description": "Modified timestamp.",
+									"example": "2018-10-11T01:05:45.000Z",
+									"format": "date-time",
+									"readOnly": true,
+									"type": "string"
+								},
+								"Name": {
+									"description": "Name of API Token",
+									"example": "gitlab-cicd",
+									"maxLength": 64,
+									"minLength": 2,
+									"pattern": "^([0-9a-zA-Z_.-]+)$",
+									"type": "string"
+								},
+								"Role": {
+									"$ref": "#\/components\/schemas\/ApiRole"
+								},
+								"Status": {
+									"description": "Status of the Token.",
+									"enum": [
+										"ACTIVE",
+										"DELETED"
+									],
+									"example": "ACTIVE",
+									"type": "string"
+								},
+								"Tags": {
+									"$ref": "#\/components\/schemas\/Tags"
+								}
+							},
+							"type": "object"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"teams.UpdateGroup": {
+				"properties": {
+					"Name": {
+						"description": "Name of User Group",
+						"example": "devops",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					}
+				},
+				"required": [
+					"Name"
+				],
+				"type": "object"
+			},
+			"teams.UpdateGroupMembers": {
+				"properties": {
+					"AddMembers": {
+						"items": {
+							"$ref": "#\/components\/schemas\/UserGroupMemberMap"
+						},
+						"type": "array"
+					},
+					"RemoveMembers": {
+						"items": {
+							"$ref": "#\/components\/schemas\/UserGroupMemberMap"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"teams.UpdateUser": {
+				"properties": {
+					"Email": {
+						"description": "Email address of User.",
+						"example": "stax.user@example.com",
+						"format": "email",
+						"maxLength": 128,
+						"minLength": 6,
+						"type": "string"
+					},
+					"FirstName": {
+						"description": "Given Name of the User.",
+						"example": "John",
+						"maxLength": 128,
+						"minLength": 0,
+						"type": "string"
+					},
+					"LastName": {
+						"description": "Family Name of the User.",
+						"example": "Doe",
+						"maxLength": 128,
+						"minLength": 0,
+						"type": "string"
+					},
+					"PhoneNumber": {
+						"description": "Phone number of User in E.164 format.",
+						"example": "+61491570006",
+						"pattern": "^\\+[1-9]\\d{4,14}$",
+						"type": "string"
+					},
+					"Role": {
+						"$ref": "#\/components\/schemas\/Role"
+					},
+					"Status": {
+						"description": "Status of User.",
+						"enum": [
+							"ACTIVE",
+							"DISABLED"
+						],
+						"type": "string"
+					}
+				},
+				"type": "object"
+			},
+			"teams.UpdateUserEvent": {
+				"allOf": [
+					{
+						"$ref": "#\/components\/schemas\/BaseEvent"
+					},
+					{
+						"properties": {
+							"Detail": {
+								"$ref": "#\/components\/schemas\/TraceEventDetail"
+							}
+						}
+					}
+				],
+				"type": "object"
+			},
+			"teams.UpdateUserInvite": {
+				"type": "object"
+			},
+			"teams.UpdateUserPassword": {
+				"type": "object"
+			},
+			"users.ReadIdamUsers": {
+				"properties": {
+					"Users": {
+						"items": {
+							"$ref": "#\/components\/schemas\/IdamUser"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"uuidv4": {
+				"example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+				"pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+				"type": "string"
+			},
+			"workloads.Catalogue": {
+				"properties": {
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"WorkloadCatalogueItems": {
+						"items": {
+							"$ref": "#\/components\/schemas\/WorkloadCatalogue"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"OrganisationId",
+					"WorkloadCatalogueItems"
+				],
+				"type": "object"
+			},
+			"workloads.CreateCatalogueItem": {
+				"properties": {
+					"Description": {
+						"description": "Description of the Workload.",
+						"example": "A Workload to build a VPC in my org",
+						"maxLength": 1024,
+						"type": "string"
+					},
+					"ManifestBody": {
+						"description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
+						"example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
+						"type": "string"
+					},
+					"ManifestURL": {
+						"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+						"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+						"type": "string"
+					},
+					"Name": {
+						"description": "Name of the Workload Catalogue Item to create.",
+						"example": "my-directory-service",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Parameters": {
+						"$ref": "#\/components\/schemas\/Parameter"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"Version": {
+						"description": "Version of the Workload Catalogue Item to create.",
+						"example": "1.0.2",
+						"maxLength": 128,
+						"type": "string"
+					}
+				},
+				"required": [
+					"Name",
+					"Version"
+				],
+				"type": "object"
+			},
+			"workloads.CreateCatalogueVersion": {
+				"properties": {
+					"Description": {
+						"description": "Description of the Workload.",
+						"example": "A Workload to build a VPC in my org",
+						"maxLength": 1024,
+						"type": "string"
+					},
+					"ManifestBody": {
+						"description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
+						"example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
+						"type": "string"
+					},
+					"ManifestURL": {
+						"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+						"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+						"type": "string"
+					},
+					"Parameters": {
+						"$ref": "#\/components\/schemas\/Parameter"
+					},
+					"Tags": {
+						"$ref": "#\/components\/schemas\/Tags"
+					},
+					"Version": {
+						"description": "Version of the Workload Catalogue Item to create.",
+						"example": "1.0.2",
+						"maxLength": 128,
+						"type": "string"
+					}
+				},
+				"required": [
+					"Version"
+				]
+			},
+			"workloads.CreateWorkload": {
+				"properties": {
+					"AccountId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"CatalogueId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"CatalogueVersionId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"Id": {
+						"$ref": "#\/components\/schemas\/ro-uuidv4"
+					},
+					"Name": {
+						"description": "The Workload name.",
+						"example": "my-workload-is-cool",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Parameters": {
+						"items": {
+							"$ref": "#\/components\/schemas\/Parameter"
+						},
+						"type": "array"
+					},
+					"Region": {
+						"description": "AWS Region the workload will be launched in",
+						"example": "us-east-1",
+						"maxLength": 32,
+						"type": "string"
+					},
+					"Tags": {
+						"anyOf": [
+							{
+								"type": "object"
+							},
+							{
+								"nullable": true
+							}
+						]
+					}
+				},
+				"required": [
+					"Name",
+					"CatalogueId",
+					"AccountId",
+					"Region"
+				],
+				"type": "object"
+			},
+			"workloads.ReadCatalogueItems": {
+				"properties": {
+					"OrganisationId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"WorkloadCatalogues": {
+						"items": {
+							"$ref": "#\/components\/schemas\/workloads.Catalogue"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"workloads.ReadCatalogueManifest": {
+				"properties": {
+					"url": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"url"
+				],
+				"type": "object"
+			},
+			"workloads.ReadCatalogueTemplate": {
+				"properties": {
+					"url": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"url"
+				],
+				"type": "object"
+			},
+			"workloads.ReadCatalogueVersion": {
+				"properties": {
+					"Versions": {
+						"items": {
+							"$ref": "#\/components\/schemas\/WorkloadCatalogueVersion"
+						},
+						"type": "array"
+					}
+				},
+				"type": "object"
+			},
+			"workloads.ReadWorkloads": {
+				"properties": {
+					"Paging": {
+						"$ref": "#\/components\/schemas\/Pagination"
+					},
+					"Workloads": {
+						"items": {
+							"$ref": "#\/components\/schemas\/Workload"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"Workloads"
+				],
+				"type": "object"
+			},
+			"workloads.UpdateAll": {
+				"properties": {
+					"CatalogueId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"CatalogueVersionId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					}
+				},
+				"required": [
+					"CatalogueId"
+				],
+				"type": "object"
+			},
+			"workloads.UpdateWorkload": {
+				"properties": {
+					"CatalogueVersionId": {
+						"$ref": "#\/components\/schemas\/uuidv4"
+					},
+					"Name": {
+						"description": "The Workload name.",
+						"example": "my-workload-is-cool",
+						"maxLength": 64,
+						"minLength": 2,
+						"type": "string"
+					},
+					"Tags": {
+						"type": "object"
+					}
+				},
+				"type": "object"
+			}
+		},
+		"securitySchemes": {
+			"sigv4": {
+				"in": "header",
+				"name": "Authorization",
+				"type": "apiKey",
+				"x-amazon-apigateway-authtype": "awsSigv4"
+			}
+		}
+	},
+	"info": {
+		"contact": {
+			"url": "https:\/\/stax.io"
+		},
+		"description": "The Stax API is organised around REST, uses resource-oriented URLs, return responses are JSON and uses standard HTTP response codes, authentication and verbs.",
+		"termsOfService": "\/there_is_no_tos",
+		"title": "Stax Core API",
+		"version": "None"
+	},
+	"openapi": "3.0.0",
+	"paths": {
+		"\/20190206\/account-types\/members": {
+			"put": {
+				"description": "Move Accounts between Account Types.<br\/>",
+				"operationId": "accounts.UpdateAccountTypeMembers",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/accounts.UpdateAccountTypeMembers"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is forbidden."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Account Type members",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/account-types\/policies": {
+			"put": {
+				"description": "Add Policies to Account types or Remove Policies from Account Types.<br\/>",
+				"operationId": "accounts.UpdatePolicies",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/accounts.UpdatePolicies"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Account Type Policies",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/accounts": {
+			"get": {
+				"description": "Return all AWS Accounts within your Stax Organisation.<br\/>Optionally, return the requested AWS Account.<br\/>",
+				"operationId": "accounts.ReadAccounts",
+				"parameters": [
+					{
+						"description": "The UUID of the Account to return.",
+						"in": "path",
+						"name": "account_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The Account statuses to return, comma delimited.\n\nFilter options available: INITIALIZING, ACTIVE, SUSPENDED, MAINTENANCE, AWSERROR, CLOSED, OFFBOARDED, DISCOVERED, ERROR.\n",
+						"in": "query",
+						"name": "filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Account IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The Account Type IDs to return, comma delimited.\n",
+						"in": "query",
+						"name": "account_type_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Pagination - The page number to return.",
+						"in": "query",
+						"name": "offset",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "Pagination - The number of items per page to return.",
+						"in": "query",
+						"name": "limit",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "The field to sort on.",
+						"in": "query",
+						"name": "sort",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The sort order - up or down?",
+						"in": "query",
+						"name": "sort_order",
+						"required": false,
+						"schema": {
+							"default": "DESC",
+							"enum": [
+								"ASC",
+								"DESC"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "Do you want all the Tags?",
+						"in": "query",
+						"name": "include_tags",
+						"required": false,
+						"schema": {
+							"default": true,
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.ReadAccounts"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Accounts",
+				"tags": [
+					"Accounts"
+				]
+			},
+			"post": {
+				"description": "Create a new Stax-hardened AWS Account in your Stax Organisation.<br\/>",
+				"operationId": "accounts.CreateAccount",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/accounts.CreateAccount"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create Account",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/accounts\/discover": {
+			"post": {
+				"description": "Discover all AWS Accounts associated with the org into stax<br\/>Optionally attempt to rediscover an Aws Account that failed discovery<br\/>",
+				"operationId": "accounts.DiscoverAccounts",
+				"parameters": [
+					{
+						"description": "The AWS Account Id of the Account to discover.",
+						"in": "path",
+						"name": "aws_account_id",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.DiscoverAccountsResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful due to user input."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the account given has already been discovered."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the requested account cannot be discovered."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Discover Accounts",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/accounts\/discover\/{aws_account_id}": {
+			"post": {
+				"description": "Discover all AWS Accounts associated with the org into stax<br\/>Optionally attempt to rediscover an Aws Account that failed discovery<br\/>",
+				"operationId": "accounts.DiscoverAccounts",
+				"parameters": [
+					{
+						"description": "The AWS Account Id of the Account to discover.",
+						"in": "path",
+						"name": "aws_account_id",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.DiscoverAccountsResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful due to user input."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the account given has already been discovered."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the requested account cannot be discovered."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Discover Accounts",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/accounts\/onboard": {
+			"post": {
+				"description": "Onboard an existing AWS Account to your Stax Organisation.<br\/>",
+				"operationId": "accounts.OnboardAccount",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/accounts.OnboardAccount"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Onboard AWS Account",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/accounts\/types": {
+			"get": {
+				"description": "Return all the Account Types in your Stax Organisation.<br\/>Optionally, return the requested Account Type.<br\/>",
+				"operationId": "accounts.ReadAccountTypes",
+				"parameters": [
+					{
+						"description": "The UUID of the Account Type.",
+						"in": "path",
+						"name": "account_type_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of AccountType IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Account Types",
+				"tags": [
+					"Accounts"
+				]
+			},
+			"post": {
+				"description": "Create a new Account Type within your Stax Organisation.<br\/>Account Types can be used to set Policies on Accounts and control Group access.<br\/>",
+				"operationId": "accounts.CreateAccountType",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/accounts.CreateAccountType"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.CreateAccountTypeResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is forbidden."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create Account Type",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/accounts\/types\/access": {
+			"put": {
+				"description": "Adjust the AWS role permissions between Account Types and Groups.<br\/>",
+				"operationId": "accounts.UpdateAccountTypeAccess",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/accounts.UpdateAccountTypeAccess"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update AWS access",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/accounts\/types\/{account_type_id}": {
+			"delete": {
+				"description": "Delete an Account Type from your Stax Organisation.<br\/>An Account Type can only be deleted if there are no attached Accounts.<br\/>",
+				"operationId": "accounts.DeleteAccountType",
+				"parameters": [
+					{
+						"description": "The UUID of the Catalogue item.",
+						"in": "path",
+						"name": "account_type_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is forbidden."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete Account Type",
+				"tags": [
+					"Accounts"
+				]
+			},
+			"get": {
+				"description": "Return all the Account Types in your Stax Organisation.<br\/>Optionally, return the requested Account Type.<br\/>",
+				"operationId": "accounts.ReadAccountTypes",
+				"parameters": [
+					{
+						"description": "The UUID of the Account Type.",
+						"in": "path",
+						"name": "account_type_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of AccountType IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Account Types",
+				"tags": [
+					"Accounts"
+				]
+			},
+			"put": {
+				"description": "Change the details of an Account Type, such as the name.<br\/>",
+				"operationId": "accounts.UpdateAccountType",
+				"parameters": [
+					{
+						"description": "The UUID of the Account Type to update.",
+						"in": "path",
+						"name": "account_type_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/accounts.UpdateAccountType"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is forbidden."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Account Type",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/accounts\/{account_id}": {
+			"get": {
+				"description": "Return all AWS Accounts within your Stax Organisation.<br\/>Optionally, return the requested AWS Account.<br\/>",
+				"operationId": "accounts.ReadAccounts",
+				"parameters": [
+					{
+						"description": "The UUID of the Account to return.",
+						"in": "path",
+						"name": "account_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The Account statuses to return, comma delimited.\n\nFilter options available: INITIALIZING, ACTIVE, SUSPENDED, MAINTENANCE, AWSERROR, CLOSED, OFFBOARDED, DISCOVERED, ERROR.\n",
+						"in": "query",
+						"name": "filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Account IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The Account Type IDs to return, comma delimited.\n",
+						"in": "query",
+						"name": "account_type_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Pagination - The page number to return.",
+						"in": "query",
+						"name": "offset",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "Pagination - The number of items per page to return.",
+						"in": "query",
+						"name": "limit",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "The field to sort on.",
+						"in": "query",
+						"name": "sort",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The sort order - up or down?",
+						"in": "query",
+						"name": "sort_order",
+						"required": false,
+						"schema": {
+							"default": "DESC",
+							"enum": [
+								"ASC",
+								"DESC"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "Do you want all the Tags?",
+						"in": "query",
+						"name": "include_tags",
+						"required": false,
+						"schema": {
+							"default": true,
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.ReadAccounts"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Accounts",
+				"tags": [
+					"Accounts"
+				]
+			},
+			"put": {
+				"description": "Change the details of an Account, such as the name, tags or Account Type<br\/>",
+				"operationId": "accounts.UpdateAccount",
+				"parameters": [
+					{
+						"description": "The UUID of the Account to update.",
+						"in": "path",
+						"name": "account_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/accounts.UpdateAccount"
+							}
+						}
+					},
+					"required": false
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is forbidden."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Account",
+				"tags": [
+					"Accounts"
+				]
+			}
+		},
+		"\/20190206\/api-tokens": {
+			"get": {
+				"description": "Return a list of all API Tokens within your Stax Organisation.<br\/>",
+				"operationId": "teams.ReadApiTokens",
+				"parameters": [
+					{
+						"description": "The UUID of the Token to return.",
+						"in": "path",
+						"name": "AccessKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Access Keys you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: ACTIVE, DELETED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.ReadApiTokens"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch API Tokens",
+				"tags": [
+					"Team",
+					"Beta"
+				]
+			},
+			"post": {
+				"description": "Create an API Token for API\/SDK access within your Stax Organisation.<br\/>",
+				"operationId": "teams.CreateApiToken",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/teams.CreateApiToken"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.CreateApiTokenResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create API Token",
+				"tags": [
+					"Team",
+					"Beta"
+				]
+			}
+		},
+		"\/20190206\/api-tokens\/{AccessKey}": {
+			"delete": {
+				"description": "Delete an API Token from your Stax Organisation.<br\/>",
+				"operationId": "teams.DeleteApiToken",
+				"parameters": [
+					{
+						"description": "The UUID of the User to delete.",
+						"in": "path",
+						"name": "AccessKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.UpdateApiTokenResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete API Token",
+				"tags": [
+					"Team",
+					"Beta"
+				]
+			},
+			"get": {
+				"description": "Return a list of all API Tokens within your Stax Organisation.<br\/>",
+				"operationId": "teams.ReadApiTokens",
+				"parameters": [
+					{
+						"description": "The UUID of the Token to return.",
+						"in": "path",
+						"name": "AccessKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Access Keys you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: ACTIVE, DELETED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.ReadApiTokens"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch API Tokens",
+				"tags": [
+					"Team",
+					"Beta"
+				]
+			},
+			"put": {
+				"description": "Update a Token for API\/SDK access within your Stax Organisation.<br\/>",
+				"operationId": "teams.UpdateApiToken",
+				"parameters": [
+					{
+						"description": "The UUID of the API Token to update.",
+						"in": "path",
+						"name": "AccessKey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/teams.UpdateApiToken"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.UpdateApiTokenResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update API Token",
+				"tags": [
+					"Team",
+					"Beta"
+				]
+			}
+		},
+		"\/20190206\/groups": {
+			"get": {
+				"description": "Return all Groups within your Stax Organisation.<br\/>Optionally, return the requested Group.<br\/>",
+				"operationId": "teams.ReadGroups",
+				"parameters": [
+					{
+						"description": "The UUID of the Group to return.",
+						"in": "path",
+						"name": "group_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Group IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.ReadGroups"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Groups",
+				"tags": [
+					"Groups"
+				]
+			},
+			"post": {
+				"description": "Create a new Group within your Stax Organisation.<br\/>",
+				"operationId": "teams.CreateGroup",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/teams.CreateGroup"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.CreateGroupResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create Group",
+				"tags": [
+					"Groups"
+				]
+			}
+		},
+		"\/20190206\/groups\/members": {
+			"put": {
+				"description": "Add members to a Group or Remove members from a Group<br\/>",
+				"operationId": "teams.UpdateGroupMembers",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/teams.UpdateGroupMembers"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "Could not locate user or group."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Group Members",
+				"tags": [
+					"Groups"
+				]
+			}
+		},
+		"\/20190206\/groups\/{group_id}": {
+			"delete": {
+				"description": "Delete a Group from your Stax Organisation.<br\/>A Group can only be deleted if there are no team members in the Group.<br\/>",
+				"operationId": "teams.DeleteGroup",
+				"parameters": [
+					{
+						"description": "The UUID of Group to delete.",
+						"in": "path",
+						"name": "group_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The Group still contains members."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The Group could not be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete Group",
+				"tags": [
+					"Groups"
+				]
+			},
+			"get": {
+				"description": "Return all Groups within your Stax Organisation.<br\/>Optionally, return the requested Group.<br\/>",
+				"operationId": "teams.ReadGroups",
+				"parameters": [
+					{
+						"description": "The UUID of the Group to return.",
+						"in": "path",
+						"name": "group_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Group IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.ReadGroups"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Groups",
+				"tags": [
+					"Groups"
+				]
+			},
+			"put": {
+				"description": "Change the details of a Group, such as the name.<br\/>",
+				"operationId": "teams.UpdateGroup",
+				"parameters": [
+					{
+						"description": "The UUID of the Group to update.",
+						"in": "path",
+						"name": "group_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/teams.UpdateGroup"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Group",
+				"tags": [
+					"Groups"
+				]
+			}
+		},
+		"\/20190206\/idam\/user": {
+			"get": {
+				"deprecated": true,
+				"description": "(DEPRECATED) Return a list of all IDAM Users in your Stax Organisation.<br\/>",
+				"operationId": "teams.ReadIdamUsers",
+				"parameters": [
+					{
+						"description": "The Organisation ID in which the IDAM is deployed to.  If no org_id is supplied, the Customer's default Organisation will be used.",
+						"in": "path",
+						"name": "org_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Do you want all the Tags?",
+						"in": "query",
+						"name": "include_tags",
+						"required": false,
+						"schema": {
+							"default": true,
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/users.ReadIdamUsers"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch IDAM Users",
+				"tags": [
+					"IDAM",
+					"Deprecated"
+				]
+			},
+			"post": {
+				"description": "Create a new Stax user within your Stax Organisation.<br\/>Stax Users have permission to access the AWS Console\/CLI for AWS Accounts that exist within a Stax Organisation.<br\/>",
+				"operationId": "teams.CreateUser",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/teams.CreateUser"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.CreateUserResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create Stax User",
+				"tags": [
+					"Team"
+				]
+			}
+		},
+		"\/20190206\/idam\/user\/resend-invite\/{user_id}": {
+			"put": {
+				"description": "Re-send the verification email for a Stax User.<br\/>",
+				"operationId": "teams.UpdateUserInvite",
+				"parameters": [
+					{
+						"description": "The UUID of the IDAM User to re-invite.",
+						"in": "path",
+						"name": "user_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.UpdateUserEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the user has already verified their email address."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the user does not exist in IDAM."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Re-invite Stax user",
+				"tags": [
+					"Team"
+				]
+			}
+		},
+		"\/20190206\/idam\/user\/reset-password\/{user_id}": {
+			"put": {
+				"description": "Send a Stax User a password reset email.<br\/>",
+				"operationId": "teams.UpdateUserPassword",
+				"parameters": [
+					{
+						"description": "The UUID of the IDAM User to have password reset.",
+						"in": "path",
+						"name": "user_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.UpdateUserEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the user has been deleted."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Reset Stax User's password",
+				"tags": [
+					"Team"
+				]
+			}
+		},
+		"\/20190206\/idam\/user\/{org_id}": {
+			"get": {
+				"deprecated": true,
+				"description": "(DEPRECATED) Return a list of all IDAM Users in your Stax Organisation.<br\/>",
+				"operationId": "teams.ReadIdamUsers",
+				"parameters": [
+					{
+						"description": "The Organisation ID in which the IDAM is deployed to.  If no org_id is supplied, the Customer's default Organisation will be used.",
+						"in": "path",
+						"name": "org_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Do you want all the Tags?",
+						"in": "query",
+						"name": "include_tags",
+						"required": false,
+						"schema": {
+							"default": true,
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/users.ReadIdamUsers"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch IDAM Users",
+				"tags": [
+					"IDAM",
+					"Deprecated"
+				]
+			}
+		},
+		"\/20190206\/idam\/user\/{user_id}": {
+			"put": {
+				"description": "Update a Stax User's details, such as the name, role or email.<br\/>",
+				"operationId": "teams.UpdateUser",
+				"parameters": [
+					{
+						"description": "The UUID of the IDAM User to update.",
+						"in": "path",
+						"name": "user_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/teams.UpdateUser"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.CreateUserResponse"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Stax User",
+				"tags": [
+					"Team"
+				]
+			}
+		},
+		"\/20190206\/networking\/dnsresolvers\/{dns_resolver_id}": {
+			"delete": {
+				"description": "<br\/>Deletes a Stax DNS Resolver within a Stax Networking Hub.<br\/>",
+				"operationId": "networking.DeleteDnsResolver",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax DNS Resolver to delete.",
+						"in": "path",
+						"name": "dns_resolver_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax Networking Hub doesn't match supplied credentials."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax DNS Resolver to delete cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete DNS Resolver",
+				"tags": [
+					"Beta"
+				]
+			},
+			"get": {
+				"description": "<br\/>Returns the DNS Resolver of the Stax Networking Hub.<br\/>Providing the UUID of a Stax DNS Resolver will return a specific Stax DNS Resolver's details.<br\/>",
+				"operationId": "networking.ReadDnsResolvers",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax Networking Hub where the Stax DNS Resolver is deployed.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Stax DNS Resolver to fetch.",
+						"in": "path",
+						"name": "dns_resolver_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Stax DNS Resolver statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadDnsResolvers"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch DNS Resolvers",
+				"tags": [
+					"Beta"
+				]
+			},
+			"put": {
+				"description": "<br\/>Updates the attributes for a given Stax DNS Resolver. Only supplied values are updated.<br\/>",
+				"operationId": "networking.UpdateDnsResolver",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax DNS Resolver to update.",
+						"in": "path",
+						"name": "dns_resolver_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.UpdateDnsResolver"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax Networking Hub doesn't match supplied credentials."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax DNS Resolver to update cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update DNS Resolver",
+				"tags": [
+					"Beta"
+				]
+			}
+		},
+		"\/20190206\/networking\/dnsresolvers\/{dns_resolver_id}\/dnsrules": {
+			"get": {
+				"description": "<br\/>Returns the Stax DNS Rules of the Stax DNS Resolver.<br\/>Providing the UUID of a Stax DNS Rule will return a specific Stax DNS Rule's details.<br\/>",
+				"operationId": "networking.ReadDnsRules",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax DNS Resolver.",
+						"in": "path",
+						"name": "dns_resolver_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Stax DNS Rule to fetch.",
+						"in": "path",
+						"name": "dns_rule_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Stax DNS Rule statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadDnsRules"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch DNS Rules",
+				"tags": [
+					"Beta"
+				]
+			},
+			"post": {
+				"description": "<br\/>Creates a Stax DNS Rule within a Stax DNS Resolver.<br\/>",
+				"operationId": "networking.CreateDnsRule",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax DNS Resolver to create the Stax DNS Rule within.",
+						"in": "path",
+						"name": "dns_resolver_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.CreateDnsRule"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax Networking Hub doesn't match supplied credentials."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax DNS Resolver to create the Stax DNS Rule within cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create DNS Rule",
+				"tags": [
+					"Beta"
+				]
+			}
+		},
+		"\/20190206\/networking\/dnsrules\/{dns_rule_id}": {
+			"delete": {
+				"description": "<br\/>Deletes a Stax DNS Rule within a Stax DNS Resolver<br\/>",
+				"operationId": "networking.DeleteDnsRule",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax DNS Rule.",
+						"in": "path",
+						"name": "dns_rule_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax Networking Hub doesn't match supplied credentials."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax DNS Rule to delete cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete DNS Rule",
+				"tags": [
+					"Beta"
+				]
+			},
+			"get": {
+				"description": "<br\/>Returns the Stax DNS Rules of the Stax DNS Resolver.<br\/>Providing the UUID of a Stax DNS Rule will return a specific Stax DNS Rule's details.<br\/>",
+				"operationId": "networking.ReadDnsRules",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax DNS Resolver.",
+						"in": "path",
+						"name": "dns_resolver_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Stax DNS Rule to fetch.",
+						"in": "path",
+						"name": "dns_rule_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Stax DNS Rule statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadDnsRules"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch DNS Rules",
+				"tags": [
+					"Beta"
+				]
+			},
+			"put": {
+				"description": "<br\/>Updates the attributes for a given Stax DNS Rule. Only supplied values are updated.<br\/>",
+				"operationId": "networking.UpdateDnsRule",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax DNS Rule to update.",
+						"in": "path",
+						"name": "dns_rule_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.UpdateDnsRule"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax Networking Hub doesn't match supplied credentials."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax DNS Rule to update cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update DNS Rule",
+				"tags": [
+					"Beta"
+				]
+			}
+		},
+		"\/20190206\/networking\/exclusions": {
+			"get": {
+				"description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
+				"operationId": "networking.ReadCidrExclusions",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub to list Exclusions in.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Exclusion to read.",
+						"in": "path",
+						"name": "exclusion_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch CIDR Exclusions",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/exclusions\/{exclusion_id}": {
+			"delete": {
+				"description": "<br\/>Deletes a CIDR Exclusion within a Stax Networking Hub.<br\/>",
+				"operationId": "networking.DeleteCidrExclusion",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub to delete the CIDR Exclusion.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Exclusion to Delete.",
+						"in": "path",
+						"name": "exclusion_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The CIDR Exclusion to delete cannot be found or is already deleted."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete CIDR Exclusion",
+				"tags": [
+					"Networking"
+				]
+			},
+			"get": {
+				"description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
+				"operationId": "networking.ReadCidrExclusions",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub to list Exclusions in.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Exclusion to read.",
+						"in": "path",
+						"name": "exclusion_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch CIDR Exclusions",
+				"tags": [
+					"Networking"
+				]
+			},
+			"put": {
+				"description": "<br\/>Updates a CIDR Exclusion within a Stax Networking Hub<br\/>",
+				"operationId": "networking.UpdateCidrExclusion",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub to update the CIDR Exclusion.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Exclusion to update.",
+						"in": "path",
+						"name": "exclusion_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.UpdateCidrExclusion"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.UpdateCidrExclusion"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The CIDR Exclusion to update cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update CIDR Exclusion",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/hubs": {
+			"get": {
+				"description": "<br\/>Returns a list of networking hubs in your Stax Organisation.<br\/>Can use the UUID of a Hub to return a specific hub details.<br\/>",
+				"operationId": "networking.ReadHubs",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, UPDATE_IN_PROGRESS, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadHubs"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Networking Hubs",
+				"tags": [
+					"Networking"
+				]
+			},
+			"post": {
+				"description": "<br\/>Creates Stax Networking Hub within your Stax Organisation.<br\/>",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.CreateHub"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The account to deploy a hub does not exist."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create Networking Hub",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/hubs\/{hub_id}": {
+			"delete": {
+				"description": "<br\/>Deletes a hub from the Stax Organisation<br\/>",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub to delete.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The hub to be deleted doesn't exist or is already deleted."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete Networking Hub",
+				"tags": [
+					"Networking"
+				]
+			},
+			"get": {
+				"description": "<br\/>Returns a list of networking hubs in your Stax Organisation.<br\/>Can use the UUID of a Hub to return a specific hub details.<br\/>",
+				"operationId": "networking.ReadHubs",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, UPDATE_IN_PROGRESS, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadHubs"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Networking Hubs",
+				"tags": [
+					"Networking"
+				]
+			},
+			"put": {
+				"description": "<br\/>Updates a various attributes for a given hub. Only supplied values are updated.<br\/>",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub to update.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.UpdateHub"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "An active hub to be updated does not exist"
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Networking Hub",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/hubs\/{hub_id}\/dnsresolvers": {
+			"get": {
+				"description": "<br\/>Returns the DNS Resolver of the Stax Networking Hub.<br\/>Providing the UUID of a Stax DNS Resolver will return a specific Stax DNS Resolver's details.<br\/>",
+				"operationId": "networking.ReadDnsResolvers",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax Networking Hub where the Stax DNS Resolver is deployed.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Stax DNS Resolver to fetch.",
+						"in": "path",
+						"name": "dns_resolver_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Stax DNS Resolver statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadDnsResolvers"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch DNS Resolvers",
+				"tags": [
+					"Beta"
+				]
+			},
+			"post": {
+				"description": "<br\/>Creates a Stax DNS Resolver within a Stax Networking Hub.<br\/>",
+				"operationId": "networking.CreateDnsResolver",
+				"parameters": [
+					{
+						"description": "The UUID of the Stax Networking Hub to deploy the Stax DNS Resolver.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.CreateDnsResolver"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Stax Networking Hub to deploy the Stax DNS Resolver cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create DNS Resolver",
+				"tags": [
+					"Beta"
+				]
+			}
+		},
+		"\/20190206\/networking\/hubs\/{hub_id}\/exclusions": {
+			"get": {
+				"description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
+				"operationId": "networking.ReadCidrExclusions",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub to list Exclusions in.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Exclusion to read.",
+						"in": "path",
+						"name": "exclusion_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch CIDR Exclusions",
+				"tags": [
+					"Networking"
+				]
+			},
+			"post": {
+				"description": "<br\/>Creates a CIDR Exclusion within a Stax Networking Hub<br\/>",
+				"operationId": "networking.CreateCidrExclusion",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub where the CIDR Exclusion is created in.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.CreateCidrExclusion"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The hub to create the CIDR Exclusion is not found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create CIDR Exclusion",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/hubs\/{hub_id}\/ranges": {
+			"get": {
+				"description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
+				"operationId": "networking.ReadCidrRanges",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub you want the Ranges for.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Range to read.",
+						"in": "path",
+						"name": "range_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch CIDR Ranges",
+				"tags": [
+					"Networking"
+				]
+			},
+			"post": {
+				"description": "<br\/>Creates a CIDR Range within a Stax Networking Hub<br\/>",
+				"operationId": "networking.CreateCidrRange",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub where the CIDR Range is created in.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.CreateCidrRange"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The hub to create the CIDR Range is not found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create CIDR Range",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/hubs\/{hub_id}\/vpcs": {
+			"get": {
+				"description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
+				"operationId": "networking.ReadVpcs",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub where the VPC is.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the VPC to read.",
+						"in": "path",
+						"name": "vpc_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+							"type": "string"
+						}
+					},
+					{
+						"description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
+						"in": "query",
+						"name": "type",
+						"required": false,
+						"schema": {
+							"default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadVpcs"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch VPCs",
+				"tags": [
+					"Networking"
+				]
+			},
+			"post": {
+				"description": "<br\/>Creates a VPC within a Stax Networking Hub<br\/>",
+				"operationId": "networking.CreateVpc",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub where the VPC is.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.CreateVpc"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "No permission to create VPC in the specified AWS Account"
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The hub to create the VPC is not found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create VPC",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/ranges": {
+			"get": {
+				"description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
+				"operationId": "networking.ReadCidrRanges",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub you want the Ranges for.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Range to read.",
+						"in": "path",
+						"name": "range_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch CIDR Ranges",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/ranges\/{range_id}": {
+			"delete": {
+				"description": "<br\/>Deletes a CIDR Range within a Stax Networking Hub. No existing VPCs can be in the CIDR Range.<br\/>",
+				"operationId": "networking.DeleteCidrRange",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub to delete the CIDR Range.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Range to delete.",
+						"in": "path",
+						"name": "range_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The CIDR Range to delete cannot be found or is already deleted."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete CIDR Range",
+				"tags": [
+					"Networking"
+				]
+			},
+			"get": {
+				"description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
+				"operationId": "networking.ReadCidrRanges",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub you want the Ranges for.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the Range to read.",
+						"in": "path",
+						"name": "range_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch CIDR Ranges",
+				"tags": [
+					"Networking"
+				]
+			},
+			"put": {
+				"description": "<br\/>Updates a CIDR Range within a Stax Networking Hub<br\/>",
+				"operationId": "networking.UpdateCidrRange",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub to update the CIDR Range.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the CIDR Range to update.",
+						"in": "path",
+						"name": "range_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.UpdateCidrRange"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.UpdateCidrRange"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The CIDR Range to update cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update CIDR Range",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/vpcs": {
+			"get": {
+				"description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
+				"operationId": "networking.ReadVpcs",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub where the VPC is.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the VPC to read.",
+						"in": "path",
+						"name": "vpc_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+							"type": "string"
+						}
+					},
+					{
+						"description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
+						"in": "query",
+						"name": "type",
+						"required": false,
+						"schema": {
+							"default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadVpcs"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch VPCs",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/networking\/vpcs\/{vpc_id}": {
+			"delete": {
+				"description": "<br\/>Deletes a VPC within a Stax Networking Hub<br\/>",
+				"operationId": "networking.DeleteVpc",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub where the VPC is.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the VPC to delete.",
+						"in": "path",
+						"name": "vpc_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The VPC to delete cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete VPC",
+				"tags": [
+					"Networking"
+				]
+			},
+			"get": {
+				"description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
+				"operationId": "networking.ReadVpcs",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub where the VPC is.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the VPC to read.",
+						"in": "path",
+						"name": "vpc_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+						"in": "query",
+						"name": "status",
+						"required": false,
+						"schema": {
+							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+							"type": "string"
+						}
+					},
+					{
+						"description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
+						"in": "query",
+						"name": "type",
+						"required": false,
+						"schema": {
+							"default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/networking.ReadVpcs"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch VPCs",
+				"tags": [
+					"Networking"
+				]
+			},
+			"put": {
+				"description": "<br\/>Updates a VPC within a Stax Networking Hub<br\/>",
+				"operationId": "networking.UpdateVpc",
+				"parameters": [
+					{
+						"description": "The UUID of the Hub where the VPC is.",
+						"in": "path",
+						"name": "hub_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					},
+					{
+						"description": "The UUID of the VPC to update.",
+						"in": "path",
+						"name": "vpc_id",
+						"required": true,
+						"schema": {
+							"$ref": "#\/components\/schemas\/uuidv4"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/networking.UpdateVpc"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The VPC to update cannot be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update VPC",
+				"tags": [
+					"Networking"
+				]
+			}
+		},
+		"\/20190206\/organisations": {
+			"get": {
+				"description": "Return a list of your Stax Organisations.<br\/>A Stax Organisation is an instance of Stax which houses your AWS Accounts, Workloads and IDAM Users.<br\/>",
+				"operationId": "organisations.ReadOrganisations",
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/organisations.ReadOrganisations"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful. The response body contains an Organisation array."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Stax Organisations",
+				"tags": [
+					"Organisations"
+				]
+			}
+		},
+		"\/20190206\/organisations\/current": {
+			"get": {
+				"description": "Return the current users Organisation.<br\/>A Stax Organisation is an instance of Stax which houses your AWS Accounts, Workloads and IDAM Users.<br\/>",
+				"operationId": "organisations.ReadOrganisation",
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/organisations.ReadOrganisations"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful. The response body contains an Organisation array."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Stax Organisations",
+				"tags": [
+					"Organisations"
+				]
+			}
+		},
+		"\/20190206\/policies": {
+			"get": {
+				"description": "Return all Policies in your Stax Organisation.<br\/>Optionally, return the requested Policy.<br\/>",
+				"operationId": "organisations.ReadPolicies",
+				"parameters": [
+					{
+						"description": "The UUID of the Policy to return.",
+						"in": "path",
+						"name": "policy_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/organisations.ReadPolicies"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Policies",
+				"tags": [
+					"Policies"
+				]
+			},
+			"post": {
+				"description": "Create a Policy in your Stax Organisation.<br\/>",
+				"operationId": "organisations.CreatePolicy",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/organisations.CreatePolicy"
+							}
+						}
+					},
+					"required": false
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/CreatePolicyEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create Policy",
+				"tags": [
+					"Policies"
+				]
+			}
+		},
+		"\/20190206\/policies\/organisation\/{policy_id}": {
+			"delete": {
+				"description": "Detach a Policy from your Stax Organisation.<br\/>The policy will no longer apply to all Account Types within the Organisation.<br\/>",
+				"operationId": "organisations:DetachPolicy",
+				"parameters": [
+					{
+						"description": "The UUID of the Policy to detach.",
+						"in": "path",
+						"name": "policy_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Detach Policy from Organisation",
+				"tags": [
+					"Policies"
+				]
+			},
+			"put": {
+				"description": "Attach a Policy to your Stax Organisation.<br\/>The policy will apply to all Account Types within the Organisation.<br\/>",
+				"operationId": "organisations:AttachPolicy",
+				"parameters": [
+					{
+						"description": "The UUID of the Policy to attach.",
+						"in": "path",
+						"name": "policy_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/organisations.AttachPolicy"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "Unable to attach foundation policy to an Organisation."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Attach Policy to Organisation",
+				"tags": [
+					"Policies"
+				]
+			}
+		},
+		"\/20190206\/policies\/{policy_id}": {
+			"delete": {
+				"description": "Delete a Policy from your Stax Organisation.<br\/>",
+				"operationId": "organisations.DeletePolicy",
+				"parameters": [
+					{
+						"description": "The UUID of the Policy to delete.",
+						"in": "path",
+						"name": "policy_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/DeletePolicyEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete Policy",
+				"tags": [
+					"Policies"
+				]
+			},
+			"get": {
+				"description": "Return all Policies in your Stax Organisation.<br\/>Optionally, return the requested Policy.<br\/>",
+				"operationId": "organisations.ReadPolicies",
+				"parameters": [
+					{
+						"description": "The UUID of the Policy to return.",
+						"in": "path",
+						"name": "policy_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/organisations.ReadPolicies"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Policies",
+				"tags": [
+					"Policies"
+				]
+			},
+			"put": {
+				"description": "Update an existing Policy within your Stax Organisation.<br\/>",
+				"operationId": "organisations.UpdatePolicy",
+				"parameters": [
+					{
+						"description": "The UUID of the Policy to update.",
+						"in": "path",
+						"name": "policy_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/organisations.UpdatePolicy"
+							}
+						}
+					},
+					"required": false
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/UpdatePolicyEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Policy",
+				"tags": [
+					"Policies"
+				]
+			}
+		},
+		"\/20190206\/public\/check-alias\/{alias}": {
+			"get": {
+				"description": "Check if an Alias is available or if it is already in use by another Stax customer.<br\/>The Alias is the unique identifier for a Customer's Stax Organisation.<br\/>",
+				"operationId": "public.CheckAlias",
+				"parameters": [
+					{
+						"description": "A unique string containing characters a-z, A-Z, 0-9.\nHyphens can also be used, but not at the start or end of the alias.\n",
+						"in": "path",
+						"name": "alias",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Alias"
+								}
+							}
+						},
+						"description": "The response returned if the Alias is available and not in use by another Customer."
+					},
+					"409": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/AliasInUse"
+								}
+							}
+						},
+						"description": "The Alias is already in use by another Customer."
+					}
+				},
+				"summary": "Check Alias availability",
+				"tags": [
+					"Public"
+				]
+			}
+		},
+		"\/20190206\/public\/config": {
+			"get": {
+				"description": "This is an unauthenticated endpoint returning your configuration variables which are required to authenticate API requests.<br\/>",
+				"operationId": "public.ReadConfig",
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Config"
+								}
+							}
+						},
+						"description": "Configuration values required to authenicate API requests."
+					}
+				},
+				"summary": "Fetch public config",
+				"tags": [
+					"Public"
+				]
+			}
+		},
+		"\/20190206\/task\/{task_id}": {
+			"get": {
+				"description": "Return the status of the requested Task.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
+				"operationId": "tasks.ReadTask",
+				"parameters": [
+					{
+						"description": "The UUID of the Task to return.",
+						"in": "path",
+						"name": "task_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Task"
+								}
+							}
+						},
+						"description": "The response returned for a valid Task."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the requested Task could not be found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch status of Task",
+				"tags": [
+					"Tasks"
+				]
+			}
+		},
+		"\/20190206\/tasks": {
+			"get": {
+				"description": "Return all Tasks for your Stax Organisation.<br\/>Optionally, return all tasks with the specified status for your Stax Organisation.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
+				"operationId": "tasks.ReadTasks",
+				"parameters": [
+					{
+						"description": "Return all tasks of this status.\n\nAccepted values are: RUNNING, SUCCEEDED or FAILED.\n",
+						"in": "path",
+						"name": "task_status",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/GetTasks"
+								}
+							}
+						},
+						"description": "The Tasks returned for a valid task_status."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The task_status not supplied or invalid."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch all Tasks by status",
+				"tags": [
+					"Tasks"
+				]
+			}
+		},
+		"\/20190206\/tasks\/{task_status}": {
+			"get": {
+				"description": "Return all Tasks for your Stax Organisation.<br\/>Optionally, return all tasks with the specified status for your Stax Organisation.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
+				"operationId": "tasks.ReadTasks",
+				"parameters": [
+					{
+						"description": "Return all tasks of this status.\n\nAccepted values are: RUNNING, SUCCEEDED or FAILED.\n",
+						"in": "path",
+						"name": "task_status",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/GetTasks"
+								}
+							}
+						},
+						"description": "The Tasks returned for a valid task_status."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The task_status not supplied or invalid."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch all Tasks by status",
+				"tags": [
+					"Tasks"
+				]
+			}
+		},
+		"\/20190206\/users": {
+			"get": {
+				"description": "Return a list of all Users within your Stax Organisation.<br\/>Optionally, return the requested User.<br\/>",
+				"operationId": "teams.ReadUsers",
+				"parameters": [
+					{
+						"description": "The UUID of the User to return.",
+						"in": "path",
+						"name": "user_id",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Users filtered by auth origin, comma delimited.\n\nFilter Options available: Team, Federated, Root\n",
+						"in": "query",
+						"name": "filter",
+						"required": false,
+						"schema": {
+							"default": "Team",
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of User IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Users filtered by Status, comma delimited.\n\nFilter Options available: ACTIVE, NEW, INVITED, DISABLED, DELETED\n",
+						"in": "query",
+						"name": "status_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.ReadUsers"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Stax Users, Federated Users, Root Users and API Tokens",
+				"tags": [
+					"Team"
+				]
+			}
+		},
+		"\/20190206\/users\/invite": {
+			"post": {
+				"description": "Invite a new Root User to your Stax Organisation.<br\/>",
+				"operationId": "teams.InviteRootUser",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/teams.InviteRootUser"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.ReadUsers"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "Only Root users can invite new Root users."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Invite New Root User",
+				"tags": [
+					"Team"
+				]
+			}
+		},
+		"\/20190206\/users\/me": {
+			"get": {
+				"description": "Returns the current logged in User.<br\/>",
+				"operationId": "teams.ReadUsers",
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.ReadUsers"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Current User",
+				"tags": [
+					"Team"
+				]
+			}
+		},
+		"\/20190206\/users\/{user_id}": {
+			"delete": {
+				"description": "Delete a Stax User from your Stax Organisation.<br\/>",
+				"operationId": "teams.DeleteUser",
+				"parameters": [
+					{
+						"description": "The UUID of the User to delete.",
+						"in": "path",
+						"name": "user_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.ReadUsers"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "User not found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete Stax User",
+				"tags": [
+					"Team"
+				]
+			},
+			"get": {
+				"description": "Return a list of all Users within your Stax Organisation.<br\/>Optionally, return the requested User.<br\/>",
+				"operationId": "teams.ReadUsers",
+				"parameters": [
+					{
+						"description": "The UUID of the User to return.",
+						"in": "path",
+						"name": "user_id",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Users filtered by auth origin, comma delimited.\n\nFilter Options available: Team, Federated, Root\n",
+						"in": "query",
+						"name": "filter",
+						"required": false,
+						"schema": {
+							"default": "Team",
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of User IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Users filtered by Status, comma delimited.\n\nFilter Options available: ACTIVE, NEW, INVITED, DISABLED, DELETED\n",
+						"in": "query",
+						"name": "status_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/teams.ReadUsers"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Stax Users, Federated Users, Root Users and API Tokens",
+				"tags": [
+					"Team"
+				]
+			}
+		},
+		"\/20190206\/workload-catalogue": {
+			"get": {
+				"description": "Return all Workload Catalogue Items within your Stax Organisation.<br\/>Optionally, return the requested Workload Catalogue Item.<br\/>",
+				"operationId": "workloads.ReadCatalogueItems",
+				"parameters": [
+					{
+						"description": "The UUID of the Catalogue Item to return.",
+						"in": "path",
+						"name": "catalogue_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The Name of the Workload Catalogue Items to return.",
+						"in": "query",
+						"name": "name",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload Catalogue Item statuses you want returned, comma delimited.\n\nFilter options available: STARTED, RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED.\n",
+						"in": "query",
+						"name": "filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload Catalogue Item IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Pagination - The page number to return.",
+						"in": "query",
+						"name": "offset",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "Pagination - The number of items per page to return.",
+						"in": "query",
+						"name": "limit",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "The field to sort on.",
+						"in": "query",
+						"name": "sort",
+						"required": false,
+						"schema": {
+							"enum": [
+								"Id",
+								"Name",
+								"Description",
+								"Status",
+								"OrganisationId",
+								"Public",
+								"CreatedTS",
+								"CreatedBy",
+								"ModifiedTS",
+								"UserTaskId",
+								"CatalogueVersionId",
+								"Protection"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "The sort order - up or down.",
+						"in": "query",
+						"name": "sort_order",
+						"required": false,
+						"schema": {
+							"default": "DESC",
+							"enum": [
+								"ASC",
+								"DESC"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "Do you want all Versions?",
+						"in": "query",
+						"name": "include_versions",
+						"required": false,
+						"schema": {
+							"default": true,
+							"type": "boolean"
+						}
+					},
+					{
+						"description": "Do you want the Parameter dictionary?",
+						"in": "query",
+						"name": "include_parameters",
+						"required": false,
+						"schema": {
+							"default": true,
+							"type": "boolean"
+						}
+					},
+					{
+						"description": "Do you want all the Tags?",
+						"in": "query",
+						"name": "include_tags",
+						"required": false,
+						"schema": {
+							"default": false,
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueItems"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if an invalid ID is entered."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if no catalogue is found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Workload Catalogue Items",
+				"tags": [
+					"Workloads"
+				]
+			},
+			"post": {
+				"description": "Create a new Workload Catalogue Item within your Stax Organisation.<br\/>",
+				"operationId": "workloads.CreateCatalogueItem",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/workloads.CreateCatalogueItem"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/CreateCatalogueEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Create Workload Catalogue Item",
+				"tags": [
+					"Workloads"
+				]
+			}
+		},
+		"\/20190206\/workload-catalogue\/manifest\/{version_id}": {
+			"get": {
+				"description": "Return a Workload Catalogue Manifest<br\/>",
+				"operationId": "workloads.ReadCatalogueManifest",
+				"parameters": [
+					{
+						"description": "The UUID of the Catalogue Version",
+						"in": "path",
+						"name": "version_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueManifest"
+								}
+							}
+						},
+						"description": "Returns the presigned url for the manifest file"
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if an invalid ID is entered."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is not successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Workload Catalogue Manifest",
+				"tags": [
+					"Workloads"
+				]
+			}
+		},
+		"\/20190206\/workload-catalogue\/template\/{version_id}\/{name}": {
+			"get": {
+				"description": "Return a specific Workload Catalogue Cloudformation Template<br\/>",
+				"operationId": "workloads.ReadCatalogueTemplate",
+				"parameters": [
+					{
+						"description": "The UUID of the Catalogue Version",
+						"in": "path",
+						"name": "version_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Retrieve the Cloudformation with this Resource Name.",
+						"in": "path",
+						"name": "name",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueTemplate"
+								}
+							}
+						},
+						"description": "Returns the presigned url to retrieve the template"
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if an invalid ID is entered."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is not successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Workload Catalogue Cloudformation Template",
+				"tags": [
+					"Workloads"
+				]
+			}
+		},
+		"\/20190206\/workload-catalogue\/{catalogue_id}": {
+			"delete": {
+				"description": "Delete a Workload Catalogue Item from your Stax Organisation.<br\/>Existing Workloads launched from this Catalogue will not be deleted.<br\/>",
+				"operationId": "workloads.DeleteCatalogueItem",
+				"parameters": [
+					{
+						"description": "The UUID of the Catalogue Item to delete.",
+						"in": "path",
+						"name": "catalogue_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/DeleteCatalogueEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Workload Catalogue can not be deleted due to running workloads."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Workload Catalogue is Protected. Protection must be disabled before you can delete it."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Workload Catalogue can not be found or does not belong to the user."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete Workload Catalogue Item",
+				"tags": [
+					"Workloads"
+				]
+			},
+			"get": {
+				"description": "Return all Workload Catalogue Items within your Stax Organisation.<br\/>Optionally, return the requested Workload Catalogue Item.<br\/>",
+				"operationId": "workloads.ReadCatalogueItems",
+				"parameters": [
+					{
+						"description": "The UUID of the Catalogue Item to return.",
+						"in": "path",
+						"name": "catalogue_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The Name of the Workload Catalogue Items to return.",
+						"in": "query",
+						"name": "name",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload Catalogue Item statuses you want returned, comma delimited.\n\nFilter options available: STARTED, RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED.\n",
+						"in": "query",
+						"name": "filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload Catalogue Item IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Pagination - The page number to return.",
+						"in": "query",
+						"name": "offset",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "Pagination - The number of items per page to return.",
+						"in": "query",
+						"name": "limit",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "The field to sort on.",
+						"in": "query",
+						"name": "sort",
+						"required": false,
+						"schema": {
+							"enum": [
+								"Id",
+								"Name",
+								"Description",
+								"Status",
+								"OrganisationId",
+								"Public",
+								"CreatedTS",
+								"CreatedBy",
+								"ModifiedTS",
+								"UserTaskId",
+								"CatalogueVersionId",
+								"Protection"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "The sort order - up or down.",
+						"in": "query",
+						"name": "sort_order",
+						"required": false,
+						"schema": {
+							"default": "DESC",
+							"enum": [
+								"ASC",
+								"DESC"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "Do you want all Versions?",
+						"in": "query",
+						"name": "include_versions",
+						"required": false,
+						"schema": {
+							"default": true,
+							"type": "boolean"
+						}
+					},
+					{
+						"description": "Do you want the Parameter dictionary?",
+						"in": "query",
+						"name": "include_parameters",
+						"required": false,
+						"schema": {
+							"default": true,
+							"type": "boolean"
+						}
+					},
+					{
+						"description": "Do you want all the Tags?",
+						"in": "query",
+						"name": "include_tags",
+						"required": false,
+						"schema": {
+							"default": false,
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueItems"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if an invalid ID is entered."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if no catalogue is found."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Workload Catalogue Items",
+				"tags": [
+					"Workloads"
+				]
+			},
+			"put": {
+				"description": "Creates a new version of a Workload Catalogue Item.<br\/>Workload Catalogue Items have one or more versions and are immutable, so any changes are a new version.<br\/>",
+				"operationId": "workloads.CreateCatalogueVersion",
+				"parameters": [
+					{
+						"description": "The UUID of the Catalogue Item to update.",
+						"in": "path",
+						"name": "catalogue_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/workloads.CreateCatalogueVersion"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/CreateVersionEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Workload Catalogue Item",
+				"tags": [
+					"Workloads"
+				]
+			}
+		},
+		"\/20190206\/workload-catalogue\/{catalogue_id}\/{version_id}": {
+			"delete": {
+				"description": "Delete a Workload Catalogue Version from your Stax Organisation.<br\/>Existing Workloads launched from this Workload Catalogue Version will not be deleted.<br\/>",
+				"operationId": "workloads.DeleteCatalogueVersion",
+				"parameters": [
+					{
+						"description": "The UUID of the Catalogue Item.",
+						"in": "path",
+						"name": "catalogue_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The UUID of the Catalogue Version to delete.",
+						"in": "path",
+						"name": "version_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/DeleteVersionEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Workload Catalogue Version can not be deleted due to running workloads."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Workload Catalogue Version can not be found or does not belong to the user."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Delete Workload Catalogue Version",
+				"tags": [
+					"Workloads"
+				]
+			},
+			"get": {
+				"description": "Return a specific Workload Catalogue Version.<br\/>",
+				"operationId": "workloads.ReadCatalogueVersion",
+				"parameters": [
+					{
+						"description": "The UUID of the Catalogue Item to return.",
+						"in": "path",
+						"name": "catalogue_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The UUID of the Catalogue Version to return.",
+						"in": "path",
+						"name": "version_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Do you want the Parameter dictionary?",
+						"in": "query",
+						"name": "include_parameters",
+						"required": false,
+						"schema": {
+							"default": true,
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueVersion"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if an invalid ID is entered."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is not successful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Workload Catalogue Version",
+				"tags": [
+					"Workloads"
+				]
+			}
+		},
+		"\/20190206\/workload-update": {
+			"post": {
+				"deprecated": true,
+				"description": "(DEPRECATED) Update all active Workloads for a specific Workload Catalogue Item.<br\/>",
+				"operationId": "workloads.UpdateAll",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/workloads.UpdateAll"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the Catalogue is not owned by the User."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update All Workloads",
+				"tags": [
+					"Workloads",
+					"Deprecated"
+				]
+			}
+		},
+		"\/20190206\/workloads": {
+			"get": {
+				"description": "Return a list of all Workloads available within your Stax Organisation.<br\/>Optionally, return the requested Workload.<br\/>",
+				"operationId": "workloads.ReadWorkloads",
+				"parameters": [
+					{
+						"description": "The UUID of the Workload Item to return.",
+						"in": "path",
+						"name": "workload_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The Name of the Workloads to return.",
+						"in": "query",
+						"name": "name",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: NEW, INITIALIZING, ACTIVE, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED, UPDATE_IN_PROGRESS, UPDATE_FAILED, UPDATE_COMPLETE.\n",
+						"in": "query",
+						"name": "filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Only return Workloads launched from this Catalogue Version.",
+						"in": "query",
+						"name": "catalogue_version_id",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Pagination - The page number to return. Must be used with limit",
+						"in": "query",
+						"name": "offset",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "Pagination - The number of items per page to return. Must be used with offset",
+						"in": "query",
+						"name": "limit",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "The field to sort on.",
+						"in": "query",
+						"name": "sort",
+						"required": false,
+						"schema": {
+							"enum": [
+								"Id",
+								"Name",
+								"AccountId",
+								"CatalogueId",
+								"CatalogueVersionId",
+								"Region",
+								"Status",
+								"UserTaskId",
+								"CreatedBy",
+								"CreatedTS",
+								"ModifiedTS",
+								"FactoryVersion"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "The sort order - up or down.",
+						"in": "query",
+						"name": "sort_order",
+						"required": false,
+						"schema": {
+							"default": "DESC",
+							"enum": [
+								"ASC",
+								"DESC"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "Do you want all the Tags?",
+						"in": "query",
+						"name": "include_tags",
+						"required": false,
+						"schema": {
+							"default": false,
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/workloads.ReadWorkloads"
+								}
+							}
+						},
+						"description": "A list of all Workloads for the logged in Customer."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the Workload ID is not a valid UUID."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the Workload ID does not exist."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Workloads",
+				"tags": [
+					"Workloads"
+				]
+			},
+			"post": {
+				"description": "Deploy a Workload within an AWS Account.<br\/>",
+				"operationId": "workloads.CreateWorkload",
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/Workload"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/CreateWorkloadEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Deploy Workload",
+				"tags": [
+					"Workloads"
+				]
+			}
+		},
+		"\/20190206\/workloads\/{workload_id}": {
+			"delete": {
+				"description": "Terminate an active Workload within an AWS Account.<br\/>",
+				"operationId": "workloads.DeleteWorkload",
+				"parameters": [
+					{
+						"description": "The UUID of the Workload to delete.",
+						"in": "path",
+						"name": "workload_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/DeleteWorkloadEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					},
+					"403": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The Workload is Protected. Protection must be disabled before you can delete it."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The Workload can not be found or does not belong to the user."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Terminate Workload",
+				"tags": [
+					"Workloads"
+				]
+			},
+			"get": {
+				"description": "Return a list of all Workloads available within your Stax Organisation.<br\/>Optionally, return the requested Workload.<br\/>",
+				"operationId": "workloads.ReadWorkloads",
+				"parameters": [
+					{
+						"description": "The UUID of the Workload Item to return.",
+						"in": "path",
+						"name": "workload_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "The Name of the Workloads to return.",
+						"in": "query",
+						"name": "name",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: NEW, INITIALIZING, ACTIVE, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED, UPDATE_IN_PROGRESS, UPDATE_FAILED, UPDATE_COMPLETE.\n",
+						"in": "query",
+						"name": "filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "List of Workload IDs you want returned, comma delimited.",
+						"in": "query",
+						"name": "id_filter",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Only return Workloads launched from this Catalogue Version.",
+						"in": "query",
+						"name": "catalogue_version_id",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "Pagination - The page number to return. Must be used with limit",
+						"in": "query",
+						"name": "offset",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "Pagination - The number of items per page to return. Must be used with offset",
+						"in": "query",
+						"name": "limit",
+						"required": false,
+						"schema": {
+							"type": "integer"
+						}
+					},
+					{
+						"description": "The field to sort on.",
+						"in": "query",
+						"name": "sort",
+						"required": false,
+						"schema": {
+							"enum": [
+								"Id",
+								"Name",
+								"AccountId",
+								"CatalogueId",
+								"CatalogueVersionId",
+								"Region",
+								"Status",
+								"UserTaskId",
+								"CreatedBy",
+								"CreatedTS",
+								"ModifiedTS",
+								"FactoryVersion"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "The sort order - up or down.",
+						"in": "query",
+						"name": "sort_order",
+						"required": false,
+						"schema": {
+							"default": "DESC",
+							"enum": [
+								"ASC",
+								"DESC"
+							],
+							"type": "string"
+						}
+					},
+					{
+						"description": "Do you want all the Tags?",
+						"in": "query",
+						"name": "include_tags",
+						"required": false,
+						"schema": {
+							"default": false,
+							"type": "boolean"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/workloads.ReadWorkloads"
+								}
+							}
+						},
+						"description": "A list of all Workloads for the logged in Customer."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the Workload ID is not a valid UUID."
+					},
+					"404": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/Error"
+								}
+							}
+						},
+						"description": "The response returned if the Workload ID does not exist."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Fetch Workloads",
+				"tags": [
+					"Workloads"
+				]
+			},
+			"put": {
+				"description": "Update a Workload running within an AWS Account.<br\/>",
+				"operationId": "workloads.UpdateWorkload",
+				"parameters": [
+					{
+						"description": "The UUID of the Workload to update.",
+						"in": "path",
+						"name": "workload_id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				],
+				"requestBody": {
+					"content": {
+						"application\/json": {
+							"schema": {
+								"$ref": "#\/components\/schemas\/workloads.UpdateWorkload"
+							}
+						}
+					},
+					"required": true
+				},
+				"responses": {
+					"200": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/UpdateWorkloadEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is successful."
+					},
+					"400": {
+						"content": {
+							"application\/json": {
+								"schema": {
+									"$ref": "#\/components\/schemas\/StaxEvent"
+								}
+							}
+						},
+						"description": "The response returned if the request is unsuccessful."
+					}
+				},
+				"security": [
+					{
+						"sigv4": []
+					}
+				],
+				"summary": "Update Workload",
+				"tags": [
+					"Workloads"
+				]
+			}
+		}
+	},
+	"servers": [
+		{
+			"url": "https:\/\/api.au1.staxapp.cloud"
+		}
+	]
 }

--- a/staxapp/data/schema.json
+++ b/staxapp/data/schema.json
@@ -1,11211 +1,8640 @@
 {
-	"components": {
-		"requestBodies": {},
-		"responses": {},
-		"schemas": {
-			"Account": {
-				"properties": {
-					"AWSLoginURLs": {
-						"properties": {
-							"admin": {
-								"type": "string"
-							},
-							"developer": {
-								"type": "string"
-							},
-							"readonly": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"AccountType": {
-						"type": "string"
-					},
-					"AllocatedTS": {
-						"description": "Allocated timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"AssuranceState": {
-						"description": "Hardening state of the Account.",
-						"enum": [
-							"NONE",
-							"UPDATING",
-							"ACTIVE",
-							"ERROR"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"AssuranceStateReason": {
-						"description": "Descriptive reason for the current AssuranceState.",
-						"example": "AWS GuardDuty Hardening has failed",
-						"readOnly": true,
-						"type": "string"
-					},
-					"AwsAccountId": {
-						"description": "AWS Account Id.",
-						"example": "012345678901",
-						"maxLength": 12,
-						"minLength": 12,
-						"readOnly": true,
-						"type": "string"
-					},
-					"AwsAccountStatusId": {
-						"type": "string"
-					},
-					"AwsLoginURL": {
-						"type": "string"
-					},
-					"CreatedBy": {
-						"description": "UUID of the account creator.",
-						"example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-						"pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-						"readOnly": true,
-						"type": "string"
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Email": {
-						"description": "Email address of account owner.",
-						"example": "stax.user@example.com",
-						"format": "email",
-						"maxLength": 128,
-						"minLength": 6,
-						"readOnly": true,
-						"type": "string"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"LatestCost": {
-						"example": 72.52,
-						"readOnly": true,
-						"type": "number"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2019-03-11T01:11:40.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Account.",
-						"example": "bakery",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"OrgsOuId": {
-						"type": "string"
-					},
-					"Origin": {
-						"description": "Origin of the Account.",
-						"enum": [
-							"STAX",
-							"External"
-						],
-						"example": "STAX",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Status": {
-						"description": "Status of the Account.",
-						"enum": [
-							"ACTIVE",
-							"AWSERROR",
-							"CLOSED",
-							"DISCOVERED",
-							"ERROR",
-							"INITIALIZING",
-							"MAINTENANCE",
-							"NEW",
-							"NOAWS",
-							"SUSPENDED"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"StaxCreated": {
-						"type": "boolean"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"UserTaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"required": [
-					"OrganisationId",
-					"Name"
-				],
-				"type": "object"
-			},
-			"AccountTask": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseTask"
-					}
-				],
-				"properties": {
-					"Accounts": {
-						"items": {
-							"$ref": "#\/components\/schemas\/ro-uuidv4"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"AccountType": {
-				"properties": {
-					"Accounts": {
-						"example": [],
-						"type": "array"
-					},
-					"CreatedBy": {
-						"description": "UUID of the account creator.",
-						"example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-						"nullable": true,
-						"pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-						"readOnly": true,
-						"type": "string"
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of Account Type.",
-						"example": "Development",
-						"maxLength": 64,
-						"minLength": 3,
-						"type": "string"
-					},
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Policies": {
-						"example": [],
-						"type": "array"
-					},
-					"Roles": {
-						"example": [],
-						"type": "array"
-					},
-					"Status": {
-						"enum": [
-							"ACTIVE",
-							"DELETED"
-						],
-						"example": "ACTIVE"
-					},
-					"StaxCreated": {
-						"type": "boolean"
-					}
-				},
-				"required": [
-					"OrganisationId",
-					"Name"
-				],
-				"type": "object"
-			},
-			"AccountTypeAccessMap": {
-				"additionalProperties": false,
-				"anyOf": [
-					{
-						"required": [
-							"AccountTypeId",
-							"GroupId",
-							"RoleName"
-						]
-					},
-					{
-						"required": [
-							"AccountTypeName",
-							"GroupId",
-							"RoleName"
-						]
-					},
-					{
-						"required": [
-							"AccountTypeId",
-							"GroupName",
-							"RoleName"
-						]
-					},
-					{
-						"required": [
-							"AccountTypeName",
-							"GroupName",
-							"RoleName"
-						]
-					}
-				],
-				"properties": {
-					"AccountTypeId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"AccountTypeName": {
-						"type": "string"
-					},
-					"GroupId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"GroupName": {
-						"type": "string"
-					},
-					"RoleName": {
-						"$ref": "#\/components\/schemas\/AwsAccessRole"
-					}
-				},
-				"type": "object"
-			},
-			"AccountTypeMemberMap": {
-				"additionalProperties": false,
-				"anyOf": [
-					{
-						"required": [
-							"AccountTypeId",
-							"AccountId"
-						]
-					},
-					{
-						"required": [
-							"AccountTypeName",
-							"AccountId"
-						]
-					}
-				],
-				"properties": {
-					"AccountId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"AccountTypeId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"AccountTypeName": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"AccountTypePolicyMap": {
-				"additionalProperties": false,
-				"anyOf": [
-					{
-						"required": [
-							"AccountTypeId",
-							"PolicyId"
-						]
-					},
-					{
-						"required": [
-							"AccountTypeName",
-							"PolicyId"
-						]
-					}
-				],
-				"properties": {
-					"AccountTypeId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"AccountTypeName": {
-						"type": "string"
-					},
-					"PolicyId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"Alias": {
-				"properties": {
-					"Alias": {
-						"properties": {
-							"Status": {
-								"enum": [
-									"The company alias provided is available",
-									"The company alias provided is already in use by another customer and cannot be used"
-								],
-								"example": "The company alias provided is available",
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"AliasInUse": {
-				"properties": {
-					"Alias": {
-						"properties": {
-							"Status": {
-								"enum": [
-									"The company alias provided is available",
-									"The company alias provided is already in use by another customer and cannot be used"
-								],
-								"example": "The company alias provided is already in use by another customer and cannot be used",
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"ApiRole": {
-				"description": "Stax role assigned to an API Token.",
-				"enum": [
-					"api_admin",
-					"api_user",
-					"api_readonly"
-				],
-				"type": "string"
-			},
-			"AwsAccessRole": {
-				"description": "AWS access roles enabled for an account type.",
-				"enum": [
-					"admin",
-					"developer",
-					"readonly"
-				],
-				"type": "string"
-			},
-			"AwsRegion": {
-				"description": "AWS Region",
-				"enum": [
-					"ap-northeast-1",
-					"ap-northeast-2",
-					"ap-south-1",
-					"ap-southeast-1",
-					"ap-southeast-2",
-					"ca-central-1",
-					"eu-central-1",
-					"eu-north-1",
-					"eu-west-1",
-					"eu-west-2",
-					"eu-west-3",
-					"sa-east-1",
-					"us-east-1",
-					"us-east-2",
-					"us-west-1",
-					"us-west-2"
-				],
-				"type": "string"
-			},
-			"BaseEvent": {
-				"properties": {
-					"DetailType": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"BaseEventDetail": {
-				"properties": {
-					"Message": {
-						"type": "string"
-					},
-					"Operation": {
-						"$ref": "#\/components\/schemas\/Operation"
-					},
-					"OperationStatus": {
-						"$ref": "#\/components\/schemas\/OperationStatus"
-					},
-					"Severity": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"BaseTask": {
-				"properties": {
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Status": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"CidrExclusion": {
-				"additionalProperties": false,
-				"properties": {
-					"Cidr": {
-						"description": "CIDR Range in quad dot notation.",
-						"example": "10.128.0.0\/19",
-						"type": "string"
-					},
-					"CreatedBy": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Description": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "Longer description of what the CIDR Exclusion is used for.",
-								"example": "datacenter exclusion",
-								"maxLength": 512,
-								"minLength": 0,
-								"type": "string"
-							}
-						]
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the CIDR Exclusion.",
-						"example": "non-prod",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"NetworkingHubId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"Status": {
-						"description": "The status of the CIRD Exclusion.",
-						"enum": [
-							"ACTIVE",
-							"DELETED",
-							"CREATE_FAILED",
-							"DELETE_FAILED"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name",
-					"Cidr"
-				],
-				"type": "object"
-			},
-			"CidrRange": {
-				"properties": {
-					"Cidr": {
-						"description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
-						"example": "10.128.0.0\/23",
-						"type": "string"
-					},
-					"CreatedBy": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"DefaultCidrRange": {
-						"description": "Boolean value declaring if the range is the default CIDR Range",
-						"example": false,
-						"type": "boolean"
-					},
-					"Description": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "Longer description of what the CIDR Range is used for.",
-								"example": "datacenter ranges",
-								"maxLength": 512,
-								"minLength": 0,
-								"type": "string"
-							}
-						]
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"LastAllocationTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the CIDR Range.",
-						"example": "non-prod",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"NetworkingHubId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Status": {
-						"description": "The status of the CIDR Range.",
-						"enum": [
-							"ACTIVE",
-							"DELETED",
-							"CREATE_FAILED",
-							"DELETE_FAILED"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name",
-					"Cidr"
-				],
-				"type": "object"
-			},
-			"Config": {
-				"properties": {
-					"API": {
-						"properties": {
-							"endpoints": {
-								"items": {
-									"$ref": "#\/components\/schemas\/ConfigEndpoint"
-								},
-								"type": "array"
-							}
-						},
-						"type": "object"
-					},
-					"Analytics": {
-						"properties": {
-							"disable": {
-								"type": "boolean"
-							}
-						},
-						"type": "object"
-					},
-					"ApiAuth": {
-						"properties": {
-							"identityPoolId": {
-								"type": "string"
-							},
-							"mandatorySignIn": {
-								"type": "boolean"
-							},
-							"region": {
-								"$ref": "#\/components\/schemas\/AwsRegion"
-							},
-							"userPoolId": {
-								"type": "string"
-							},
-							"userPoolWebClientId": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"AppSync": {
-						"properties": {
-							"analytics": {
-								"properties": {
-									"endpoint": {
-										"type": "string"
-									},
-									"region": {
-										"$ref": "#\/components\/schemas\/AwsRegion"
-									}
-								},
-								"type": "object"
-							},
-							"core": {
-								"properties": {
-									"endpoint": {
-										"type": "string"
-									},
-									"region": {
-										"$ref": "#\/components\/schemas\/AwsRegion"
-									}
-								},
-								"type": "object"
-							},
-							"graphqlEndpoint": {
-								"type": "string"
-							},
-							"region": {
-								"$ref": "#\/components\/schemas\/AwsRegion"
-							}
-						},
-						"type": "object"
-					},
-					"Auth": {
-						"properties": {
-							"identityPoolId": {
-								"type": "string"
-							},
-							"mandatorySignIn": {
-								"type": "boolean"
-							},
-							"region": {
-								"$ref": "#\/components\/schemas\/AwsRegion"
-							},
-							"userPoolId": {
-								"type": "string"
-							},
-							"userPoolWebClientId": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"Juma": {
-						"properties": {
-							"controlplaneRegion": {
-								"type": "string"
-							},
-							"domainName": {
-								"type": "string"
-							},
-							"fullDomainName": {
-								"type": "string"
-							},
-							"masterAccountId": {
-								"type": "string"
-							},
-							"rootOrgId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"stage": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"JumaAuth": {
-						"properties": {
-							"identityPoolId": {
-								"type": "string"
-							},
-							"mandatorySignIn": {
-								"type": "boolean"
-							},
-							"region": {
-								"$ref": "#\/components\/schemas\/AwsRegion"
-							},
-							"userPoolId": {
-								"type": "string"
-							},
-							"userPoolWebClientId": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"Pingdom": {
-						"properties": {
-							"key": {
-								"nullable": true,
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"SNS": {
-						"properties": {
-							"event": {
-								"type": "string"
-							},
-							"notify": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"Sentry": {
-						"properties": {
-							"dsn": {
-								"type": "string"
-							},
-							"projectName": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"Storage": {
-						"properties": {
-							"bucket": {
-								"type": "string"
-							},
-							"region": {
-								"$ref": "#\/components\/schemas\/AwsRegion"
-							}
-						},
-						"type": "object"
-					},
-					"Zone": {
-						"properties": {
-							"key": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"required": [
-					"Auth",
-					"API"
-				],
-				"type": "object"
-			},
-			"ConfigEndpoint": {
-				"properties": {
-					"endpoint": {
-						"type": "string"
-					},
-					"name": {
-						"type": "string"
-					},
-					"region": {
-						"$ref": "#\/components\/schemas\/AwsRegion"
-					}
-				},
-				"type": "object"
-			},
-			"CreateCatalogueDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"TraceId": {
-						"type": "string"
-					},
-					"WorkloadCatalogueItem": {
-						"properties": {
-							"CatalogueId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Description": {
-								"description": "Description of the Workload.",
-								"example": "A Workload to build a VPC in my org",
-								"maxLength": 1024,
-								"type": "string"
-							},
-							"ManifestURL": {
-								"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-								"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-								"type": "string"
-							},
-							"Name": {
-								"description": "Name of the Workload Catalogue Item to create.",
-								"example": "my-directory-service",
-								"maxLength": 64,
-								"minLength": 2,
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Public": {
-								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-								"example": false,
-								"type": "boolean"
-							},
-							"Tags": {
-								"$ref": "#\/components\/schemas\/Tags"
-							},
-							"Version": {
-								"example": "0.01",
-								"readOnly": true,
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"CreateCatalogueEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"CatalogueId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CustomerId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Detail": {
-						"$ref": "#\/components\/schemas\/CreateCatalogueDetail"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"TraceId": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"CreatePolicyDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"Policy": {
-						"properties": {
-							"CreatedBy": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"CustomerId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Description": {
-								"description": "Description of the Policy.",
-								"example": "A service control policy that denies access to all.",
-								"maxLength": 1024,
-								"minLength": 3,
-								"type": "string"
-							},
-							"Name": {
-								"description": "Name of the Policy.",
-								"example": "DenyAll",
-								"maxLength": 128,
-								"minLength": 3,
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OrgId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Policy": {
-								"type": "string"
-							},
-							"PolicyId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TaskId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TraceId": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"CreatePolicyEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"Detail": {
-						"$ref": "#\/components\/schemas\/CreatePolicyDetail"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"CreateVersionDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"TraceId": {
-						"type": "string"
-					},
-					"WorkloadCatalogueItem": {
-						"properties": {
-							"CatalogueId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Description": {
-								"description": "Description of the Workload.",
-								"example": "A Workload to build a VPC in my org",
-								"maxLength": 1024,
-								"type": "string"
-							},
-							"ManifestBody": {
-								"description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
-								"example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
-								"type": "string"
-							},
-							"ManifestURL": {
-								"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-								"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Parameters": {
-								"$ref": "#\/components\/schemas\/Parameter"
-							},
-							"Public": {
-								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-								"example": false,
-								"type": "boolean"
-							},
-							"Version": {
-								"example": "0.01",
-								"readOnly": true,
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"CreateVersionEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"CatalogueId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CustomerId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Detail": {
-						"$ref": "#\/components\/schemas\/CreateVersionDetail"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"TraceId": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"CreateWorkloadDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"Workload": {
-						"properties": {
-							"AccountId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"CatalogueId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"CatalogueVersionId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"CreatedBy": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Name": {
-								"description": "The Workload name.",
-								"example": "my-workload-is-cool",
-								"maxLength": 64,
-								"minLength": 2,
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OrgId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"Parameters": {
-								"$ref": "#\/components\/schemas\/Parameter"
-							},
-							"Region": {
-								"description": "AWS Region the workload will be launched in",
-								"example": "us-east-1",
-								"maxLength": 32,
-								"type": "string"
-							},
-							"Tags": {
-								"$ref": "#\/components\/schemas\/Tags"
-							},
-							"TaskId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"TraceId": {
-								"type": "string"
-							},
-							"WorkloadId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"CreateWorkloadEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"Detail": {
-						"$ref": "#\/components\/schemas\/CreateWorkloadDetail"
-					},
-					"WorkloadId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"Customer": {
-				"properties": {
-					"CognitoUserId": {
-						"description": "Cognito User unique identifier.",
-						"example": "my-user-id",
-						"readOnly": true,
-						"type": "string"
-					},
-					"CreatedBy": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Email": {
-						"description": "Email address of the User.",
-						"example": "stax.user@example.com",
-						"format": "email",
-						"maxLength": 128,
-						"minLength": 6,
-						"type": "string"
-					},
-					"FactoryVersion": {
-						"$ref": "#\/components\/schemas\/GitHash"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Account.",
-						"example": "My Business",
-						"maxLength": 64,
-						"minLength": 3,
-						"type": "string"
-					},
-					"Status": {
-						"description": "Status of the Customer.",
-						"enum": [
-							"PROSPECT",
-							"NEW",
-							"INITIALIZING",
-							"ACTIVE",
-							"SUSPENDED"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"SupportPlan": {
-						"description": "Stax Support Plan allocated to the Customer.",
-						"enum": [
-							"BASIC",
-							"BUSINESS",
-							"ENTERPRISE"
-						],
-						"example": "BUSINESS",
-						"type": "string"
-					},
-					"UserTaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"required": [
-					"Name",
-					"Email"
-				],
-				"type": "object"
-			},
-			"DNSResolver": {
-				"additionalProperties": false,
-				"properties": {
-					"CreatedBy": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"InboundIpAddresses": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The IP Addresses attached to the Inbound DNS Resolver.",
-								"example": [
-									"192.168.0.1",
-									"192.168.0.2"
-								],
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"Interfaces": {
-						"description": "The number of ENIs to attach to the DNS Resolvers.",
-						"example": 2,
-						"type": "integer"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Stax DNS Resolvers.",
-						"example": "dns",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"NetworkingHubId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"OutboundIpAddresses": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The IP Addresses attached to the Outbound DNS Resolver.",
-								"example": [
-									"192.168.0.1",
-									"192.168.0.2"
-								],
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"Status": {
-						"description": "The status of the Stax DNS Resolvers.",
-						"enum": [
-							"ACTIVE",
-							"CREATE_IN_PROGRESS",
-							"CREATE_FAILED",
-							"DELETE_IN_PROGRESS",
-							"DELETED",
-							"DELETE_FAILED",
-							"UPDATE_IN_PROGRESS"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"UserTaskId": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					}
-				},
-				"required": [
-					"Name",
-					"NetworkingHubId",
-					"Interfaces"
-				],
-				"type": "object"
-			},
-			"DNSRule": {
-				"additionalProperties": false,
-				"properties": {
-					"AwsRuleId": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The AWS Route53 Resolver Rule Id.",
-								"readOnly": true,
-								"type": "string"
-							}
-						]
-					},
-					"CreatedBy": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"DnsResolverId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"DomainName": {
-						"description": "Domain name to forward DNS queries for.",
-						"example": "test.local",
-						"maxLength": 128,
-						"minLength": 2,
-						"type": "string"
-					},
-					"ForwarderIpAddresses": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The IP Addresses to forward DNS queries to.",
-								"example": [
-									"192.168.0.1",
-									"192.168.0.2"
-								],
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of Stax DNS Rule.",
-						"example": "on-premises",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Status": {
-						"description": "The status of the Stax DNS Rule.",
-						"enum": [
-							"ACTIVE",
-							"CREATE_IN_PROGRESS",
-							"CREATE_FAILED",
-							"DELETE_IN_PROGRESS",
-							"DELETED",
-							"DELETE_FAILED",
-							"UPDATE_IN_PROGRESS"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"UserTaskId": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					}
-				},
-				"required": [
-					"Name",
-					"DomainName",
-					"DnsResolverId"
-				],
-				"type": "object"
-			},
-			"DeleteCatalogueDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"AdditionalMetaData": {
-						"properties": {
-							"CatalogueVersionId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"CreatedBy": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"CreatedTS": {
-								"description": "Created timestamp.",
-								"example": "2018-10-11T01:05:45.000Z",
-								"format": "date-time",
-								"readOnly": true,
-								"type": "string"
-							},
-							"Description": {
-								"description": "Description of the Workload.",
-								"example": "A Workload to build a VPC in my org",
-								"maxLength": 1024,
-								"type": "string"
-							},
-							"Id": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"ModifiedTS": {
-								"description": "Modified timestamp.",
-								"example": "2018-10-11T01:05:45.000Z",
-								"format": "date-time",
-								"readOnly": true,
-								"type": "string"
-							},
-							"Name": {
-								"description": "Name of the Workload Catalogue Item to create.",
-								"example": "my-directory-service",
-								"maxLength": 64,
-								"minLength": 2,
-								"type": "string"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"Protection": {
-								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-								"example": false,
-								"type": "boolean"
-							},
-							"Public": {
-								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-								"example": false,
-								"type": "boolean"
-							},
-							"Status": {
-								"description": "Status of the Workload.",
-								"enum": [
-									"NEW",
-									"UPLOADING",
-									"VALIDATING",
-									"ACTIVE",
-									"DELETED",
-									"FAILED"
-								],
-								"example": "NEW",
-								"readOnly": true,
-								"type": "string"
-							},
-							"UserTaskId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						},
-						"type": "object"
-					},
-					"TraceId": {
-						"type": "string"
-					},
-					"WorkloadCatalogueItem": {
-						"$ref": "#\/components\/schemas\/Operation"
-					}
-				},
-				"type": "object"
-			},
-			"DeleteCatalogueEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"CatalogueId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CustomerId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Detail": {
-						"$ref": "#\/components\/schemas\/DeleteCatalogueDetail"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"TraceId": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"DeletePolicyDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"Policy": {
-						"properties": {
-							"CreatedBy": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"CustomerId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OrgId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"PolicyId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TaskId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TraceId": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"DeletePolicyEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"Detail": {
-						"$ref": "#\/components\/schemas\/DeletePolicyDetail"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"DeleteVersionDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"AdditionalMetaData": {
-						"properties": {
-							"CatalogueId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"CreatedBy": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"CreatedTS": {
-								"description": "Created timestamp.",
-								"example": "2018-10-11T01:05:45.000Z",
-								"format": "date-time",
-								"readOnly": true,
-								"type": "string"
-							},
-							"Description": {
-								"description": "Description of the Workload.",
-								"example": "A Workload to build a VPC in my org",
-								"maxLength": 1024,
-								"type": "string"
-							},
-							"Id": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"ManifestURL": {
-								"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-								"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-								"type": "string"
-							},
-							"ModifiedTS": {
-								"description": "Modified timestamp.",
-								"example": "2018-10-11T01:05:45.000Z",
-								"format": "date-time",
-								"readOnly": true,
-								"type": "string"
-							},
-							"Outputs": {
-								"items": {
-									"example": "bread",
-									"type": "string"
-								},
-								"nullable": true,
-								"readOnly": true,
-								"type": "array"
-							},
-							"Public": {
-								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-								"example": false,
-								"type": "boolean"
-							},
-							"Status": {
-								"description": "Status of the Workload.",
-								"enum": [
-									"NEW",
-									"UPLOADING",
-									"VALIDATING",
-									"ACTIVE",
-									"DELETED",
-									"FAILED"
-								],
-								"example": "NEW",
-								"readOnly": true,
-								"type": "string"
-							},
-							"UserTaskId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"WorkloadCatalogueName": {
-								"description": "Name of the Workload Catalogue Item to create.",
-								"example": "my-directory-service",
-								"maxLength": 64,
-								"minLength": 2,
-								"type": "string"
-							},
-							"WorkloadVersion": {
-								"example": "0.01",
-								"readOnly": true,
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"TraceId": {
-						"type": "string"
-					},
-					"WorkloadCatalogueVersion": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"DeleteVersionEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"CatalogueId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CustomerId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Detail": {
-						"$ref": "#\/components\/schemas\/DeleteVersionDetail"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"TraceId": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"DeleteWorkloadDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"Workload": {
-						"properties": {
-							"AccountId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"CatalogueVersionId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"CreatedBy": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Name": {
-								"description": "The Workload name.",
-								"example": "my-workload-is-cool",
-								"maxLength": 64,
-								"minLength": 2,
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OrgId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"Parameters": {
-								"$ref": "#\/components\/schemas\/Parameter"
-							},
-							"Region": {
-								"description": "AWS Region the workload will be launched in",
-								"example": "us-east-1",
-								"maxLength": 32,
-								"type": "string"
-							},
-							"TaskId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"TraceId": {
-								"type": "string"
-							},
-							"WorkloadId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"DeleteWorkloadEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"Detail": {
-						"$ref": "#\/components\/schemas\/DeleteWorkloadDetail"
-					}
-				},
-				"type": "object"
-			},
-			"Error": {
-				"properties": {
-					"Cause": {
-						"type": "string"
-					},
-					"Error": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"GetTasks": {
-				"properties": {
-					"Tasks": {
-						"$ref": "#\/components\/schemas\/Task"
-					}
-				},
-				"type": "object"
-			},
-			"GitHash": {
-				"example": "f8cf81b",
-				"maxLength": 7,
-				"minLength": 7,
-				"readOnly": true,
-				"type": "string"
-			},
-			"Group": {
-				"properties": {
-					"CreatedBy": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Group.",
-						"example": "DevOps",
-						"maxLength": 128,
-						"minLength": 3,
-						"type": "string"
-					},
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Status": {
-						"description": "Status of the Group.",
-						"enum": [
-							"ACTIVE",
-							"DELETED"
-						],
-						"example": "ACTIVE",
-						"type": "string"
-					},
-					"UserTaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Users": {
-						"description": "Array of IDs of Users belonging to the Group.",
-						"items": {
-							"$ref": "#\/components\/schemas\/ro-uuidv4"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"Id",
-					"Name"
-				],
-				"type": "object"
-			},
-			"IdamUser": {
-				"properties": {
-					"id": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					}
-				},
-				"required": [
-					"id"
-				],
-				"type": "object"
-			},
-			"NetworkingHub": {
-				"additionalProperties": false,
-				"properties": {
-					"AccountId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"Asn": {
-						"description": "A private Autonomous System Number (ASN) for the Amazon side of a BGP session",
-						"example": 64512,
-						"type": "integer"
-					},
-					"CreatedBy": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Description": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "Longer description of what the Stax Networking Hub is used for.",
-								"example": "my-hub",
-								"maxLength": 512,
-								"minLength": 0,
-								"type": "string"
-							}
-						]
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"InterfaceEndpoints": {
-						"items": {
-							"$ref": "#\/components\/schemas\/interface-endpoint"
-						},
-						"type": "array"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of Stax Networking Hub.",
-						"example": "non-prod",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"PhzSuffix": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
-								"example": "my-domain.cloud",
-								"type": "string"
-							}
-						]
-					},
-					"Region": {
-						"$ref": "#\/components\/schemas\/AwsRegion"
-					},
-					"Status": {
-						"description": "The status of the Stax Networking Hub.",
-						"enum": [
-							"ACTIVE",
-							"CREATE_IN_PROGRESS",
-							"CREATE_FAILED",
-							"DELETE_IN_PROGRESS",
-							"DELETED",
-							"DELETE_FAILED",
-							"UPDATE_IN_PROGRESS"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"UserTaskId": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					}
-				},
-				"required": [
-					"Name",
-					"AccountId",
-					"Region"
-				],
-				"type": "object"
-			},
-			"Operation": {
-				"enum": [
-					"CREATE",
-					"READ",
-					"UPDATE",
-					"DELETE",
-					"accounts:CreateAccount",
-					"accounts:CreateAccountType",
-					"accounts:DiscoverAccounts",
-					"accounts:DeleteAccountType",
-					"accounts:ReadAccountTypes",
-					"accounts:ReadAccounts",
-					"accounts:UpdateAccount",
-					"accounts:UpdateAccountType",
-					"accounts:UpdateAccountTypeAccess",
-					"accounts:UpdateAccountTypeMembers",
-					"accounts:UpdatePolicies",
-					"organisations:AttachPolicy",
-					"organisations:CreatePolicy",
-					"organisations:DeletePolicy",
-					"organisations:DetachPolicy",
-					"organisations:ReadPolicies",
-					"organisations:UpdatePolicy",
-					"teams:CreateApiToken",
-					"teams:CreateGroup",
-					"teams:CreateUser",
-					"teams:DeleteApiToken",
-					"teams:DeleteGroup",
-					"teams:DeleteUser",
-					"teams:ReadApiTokens",
-					"teams:ReadGroups",
-					"teams:ReadUsers",
-					"teams:UpdateApiToken",
-					"teams:UpdateGroup",
-					"teams:UpdateGroupMembers",
-					"teams:UpdateUser",
-					"teams:UpdateUserPassword",
-					"workloads:CreateCatalogueItem",
-					"workloads:CreateCatalogueVersion",
-					"workloads:CreateWorkload",
-					"workloads:DeleteCatalogueItem",
-					"workloads:DeleteCatalogueVersion",
-					"workloads:DeleteWorkload",
-					"workloads:ReadWorkloadCatalogueItems",
-					"workloads:ReadWorkloads",
-					"workloads:UpdateWorkload",
-					"networking:CreateHub",
-					"networking:UpdateHub",
-					"networking:DeleteHub",
-					"networking:CreateVpc",
-					"networking:UpdateVpc",
-					"networking:DeleteVpc",
-					"networking:CreateDnsResolver",
-					"networking:UpdateDnsResolver",
-					"networking:DeleteDnsResolver",
-					"networking:CreateDnsRule",
-					"networking:UpdateDnsRule",
-					"networking:DeleteDnsRule"
-				],
-				"type": "string"
-			},
-			"OperationStatus": {
-				"enum": [
-					"STARTED",
-					"RUNNING",
-					"SUCCEEDED",
-					"FAILED",
-					"TIMED_OUT",
-					"ABORTED"
-				],
-				"type": "string"
-			},
-			"Organisation": {
-				"properties": {
-					"Alias": {
-						"description": "Alias for your Organisation. This alias will be used in the URL of your Stax Identity Broker.",
-						"example": "my-stax-org",
-						"maxLength": 64,
-						"minLength": 3,
-						"type": "string"
-					},
-					"AllowedDomains": {
-						"description": "Allowed email domains for the Organisation, this limits who can be invited to your Team.",
-						"example": "@example.com,@stax.io",
-						"maxLength": 64,
-						"minLength": 3,
-						"nullable": true,
-						"type": "string"
-					},
-					"AttachedPolicies": {
-						"items": {
-							"$ref": "#\/components\/schemas\/ro-uuidv4"
-						},
-						"readOnly": true,
-						"type": "array"
-					},
-					"AwsAccountEmailTemplate": {
-						"description": "AWS Accounts will be registered with email addresses fitting this pattern. Please ensure these email addresses are secured, as they can be used for Root Credential recovery.",
-						"example": "stax.user+${Stax::AccountId}@example.com",
-						"maxLength": 64,
-						"minLength": 3,
-						"nullable": true,
-						"type": "string"
-					},
-					"AwsPartnerSupport": {
-						"description": "AWS Partner Led Support - if you have partner led support then Stax Support will open AWS Support cases on your behalf.",
-						"type": "boolean"
-					},
-					"AwsSupportType": {
-						"description": "Default AWS Support level set on Accounts in your Organisation.",
-						"enum": [
-							"BASIC",
-							"DEVELOPER",
-							"BUSINESS",
-							"ENTERPRISE"
-						],
-						"example": "ENTERPRISE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"CreatedBy": {
-						"anyOf": [
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							{
-								"nullable": true
-							}
-						]
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"CustomerId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ExternalStaxId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Organisation",
-						"example": "default",
-						"maxLength": 64,
-						"minLength": 3,
-						"type": "string"
-					},
-					"Region": {
-						"$ref": "#\/components\/schemas\/AwsRegion"
-					},
-					"SpotlightSsoURL": {
-						"readOnly": true,
-						"type": "string"
-					},
-					"Status": {
-						"description": "Status of the Organisation.",
-						"enum": [
-							"NEW",
-							"INITIALIZING",
-							"ACTIVE",
-							"SUSPENDED"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"UserTaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"Pagination": {
-				"description": "Pagination metadata. Present when limit and offset parameters are supplied.",
-				"properties": {
-					"NextOffset": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "Offset value to provide to retrieve the next set of items. Null when there are no more pages to fetch.",
-								"example": 20,
-								"type": "number"
-							}
-						]
-					},
-					"PrevOffset": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "Offset value to provide to retrieve the previous set of items. Null when the first page is returned.",
-								"example": null,
-								"type": "number"
-							}
-						]
-					},
-					"Total": {
-						"description": "Total number of items in the full pagination set after filters are applied.",
-						"example": 100,
-						"type": "number"
-					}
-				},
-				"required": [
-					"Total",
-					"NextOffset",
-					"PrevOffset"
-				],
-				"type": "object"
-			},
-			"Parameter": {
-				"example": {
-					"Key": "Bread",
-					"Value": "Croissant"
-				},
-				"nullable": true,
-				"properties": {
-					"Key": {
-						"maxLength": 255,
-						"minLength": 1,
-						"type": "string"
-					},
-					"Value": {
-						"oneOf": [
-							{
-								"maxLength": 4096,
-								"minLength": 1,
-								"type": "string"
-							},
-							{
-								"type": "integer"
-							}
-						]
-					}
-				},
-				"type": "object"
-			},
-			"Policy": {
-				"properties": {
-					"AttachableTo": {
-						"description": "Whether a policy is org only or account type only, or both",
-						"enum": [
-							"ORG",
-							"ACCOUNT_TYPE",
-							"ANY"
-						],
-						"example": "ANY",
-						"readOnly": false,
-						"type": "string"
-					},
-					"CreatedBy": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Description": {
-						"description": "Description of the Policy.",
-						"example": "A service control policy that denies access to all.",
-						"maxLength": 1024,
-						"minLength": 3,
-						"type": "string"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Mandatory": {
-						"description": "Boolean value declaring if the policy is mandatory or not.",
-						"example": false,
-						"type": "boolean"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Policy.",
-						"example": "DenyAll",
-						"maxLength": 128,
-						"minLength": 3,
-						"type": "string"
-					},
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Policy": {
-						"type": "string"
-					},
-					"Public": {
-						"description": "Boolean value declaring if the policy is public or private.",
-						"example": false,
-						"type": "boolean"
-					},
-					"Status": {
-						"description": "Status of the policy.",
-						"enum": [
-							"ACTIVE",
-							"DELETED",
-							"FAILED"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"Resource": {
-				"properties": {
-					"ResourceId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ResourceType": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"Role": {
-				"description": "Stax role assigned to user.",
-				"enum": [
-					"customer_root",
-					"customer_admin",
-					"customer_user",
-					"customer_readonly"
-				],
-				"example": "customer_admin",
-				"type": "string"
-			},
-			"StaxEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"Details": {
-						"$ref": "#\/components\/schemas\/TaskEventDetail"
-					}
-				}
-			},
-			"Tags": {
-				"anyOf": [
-					{
-						"additionalProperties": {
-							"type": "string"
-						},
-						"maxProperties": 100,
-						"minProperties": 1,
-						"type": "object"
-					},
-					{
-						"nullable": true
-					}
-				],
-				"example": {
-					"CostCode": "12345"
-				}
-			},
-			"Task": {
-				"$ref": "#\/components\/schemas\/WorkloadTask"
-			},
-			"TaskEventDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				}
-			},
-			"TraceEventDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"TraceId": {
-						"type": "string"
-					}
-				}
-			},
-			"UpdateCatalogueDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"TraceId": {
-						"type": "string"
-					},
-					"WorkloadCatalogueItem": {
-						"properties": {
-							"CatalogueId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Description": {
-								"description": "Description of the Workload.",
-								"example": "A Workload to build a VPC in my org",
-								"maxLength": 1024,
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Public": {
-								"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-								"example": false,
-								"type": "boolean"
-							},
-							"Version": {
-								"example": "0.01",
-								"readOnly": true,
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"UpdateCatalogueEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"CatalogueId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CustomerId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Detail": {
-						"$ref": "#\/components\/schemas\/UpdateCatalogueDetail"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"TraceId": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"UpdatePolicyDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"Policy": {
-						"properties": {
-							"CreatedBy": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"CustomerId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Name": {
-								"description": "Name of the Policy.",
-								"example": "DenyAll",
-								"maxLength": 128,
-								"minLength": 3,
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OrgId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"PolicyId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TaskId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TraceId": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"UpdatePolicyEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"Detail": {
-						"$ref": "#\/components\/schemas\/UpdatePolicyDetail"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"UpdateWorkloadDetail": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEventDetail"
-					}
-				],
-				"properties": {
-					"Workload": {
-						"properties": {
-							"AccountId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"CatalogueVersionId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"CreatedBy": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"Name": {
-								"description": "The Workload name.",
-								"example": "my-workload-is-cool",
-								"maxLength": 64,
-								"minLength": 2,
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OrgId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"OrganisationId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"Parameters": {
-								"$ref": "#\/components\/schemas\/Parameter"
-							},
-							"Region": {
-								"description": "AWS Region the workload will be launched in",
-								"example": "us-east-1",
-								"maxLength": 32,
-								"type": "string"
-							},
-							"TaskId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							},
-							"TraceId": {
-								"type": "string"
-							},
-							"WorkloadId": {
-								"$ref": "#\/components\/schemas\/uuidv4"
-							}
-						},
-						"type": "object"
-					}
-				},
-				"type": "object"
-			},
-			"UpdateWorkloadEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					}
-				],
-				"properties": {
-					"Detail": {
-						"$ref": "#\/components\/schemas\/UpdateWorkloadDetail"
-					},
-					"WorkloadId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"User": {
-				"properties": {
-					"AuthOrigin": {
-						"example": "idam",
-						"readOnly": true,
-						"type": "string"
-					},
-					"CreatedBy": {
-						"oneOf": [
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							{
-								"nullable": true
-							}
-						]
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"CustomerId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"Description": {
-						"example": "Marketing User",
-						"nullable": true,
-						"type": "string"
-					},
-					"Email": {
-						"description": "Email address of User.",
-						"example": "stax.user@example.com",
-						"format": "email",
-						"maxLength": 128,
-						"minLength": 6,
-						"readOnly": true,
-						"type": "string"
-					},
-					"FirstName": {
-						"oneOf": [
-							{
-								"description": "Given Name of the User.",
-								"example": "John",
-								"maxLength": 128,
-								"minLength": 0,
-								"type": "string"
-							},
-							{
-								"nullable": true
-							}
-						]
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"LastName": {
-						"oneOf": [
-							{
-								"description": "Family Name of the User.",
-								"example": "Doe",
-								"maxLength": 128,
-								"minLength": 0,
-								"type": "string"
-							},
-							{
-								"nullable": true
-							}
-						]
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Concatenation of first and last name. Defaults to email address if neither are present.",
-						"example": "John Doe",
-						"maxLength": 128,
-						"minLength": 3,
-						"type": "string"
-					},
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"PhoneNumber": {
-						"description": "Phone number of User in E.164 format.",
-						"example": "+61491570006",
-						"nullable": true,
-						"pattern": "^\\+[1-9]\\d{4,14}$",
-						"type": "string"
-					},
-					"Role": {
-						"$ref": "#\/components\/schemas\/Role"
-					},
-					"Status": {
-						"description": "Status of the User.",
-						"enum": [
-							"ACTIVE",
-							"DISABLED",
-							"DELETED",
-							"INVITED",
-							"NEW"
-						],
-						"example": "ACTIVE",
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"UserTaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"required": [
-					"Id",
-					"Email",
-					"Name",
-					"OrganisationId"
-				],
-				"type": "object"
-			},
-			"UserGroupMemberMap": {
-				"additionalProperties": false,
-				"properties": {
-					"GroupId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"UserId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					}
-				},
-				"type": "object"
-			},
-			"UserTask": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseTask"
-					}
-				],
-				"properties": {
-					"Users": {
-						"items": {
-							"$ref": "#\/components\/schemas\/ro-uuidv4"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"VPC": {
-				"additionalProperties": false,
-				"properties": {
-					"AccountId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"AwsVpcId": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The AWS VPC ID.",
-								"readOnly": true,
-								"type": "string"
-							}
-						]
-					},
-					"Cidr": {
-						"description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
-						"example": "10.128.0.0\/23",
-						"type": "string"
-					},
-					"CidrRangeId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"CreateIgw": {
-						"description": "Boolean value declaring if Internet Gateway is enabled",
-						"example": true,
-						"type": "boolean"
-					},
-					"CreateNat": {
-						"description": "Boolean value declaring if NAT Gateways is enabled",
-						"example": true,
-						"type": "boolean"
-					},
-					"CreatedBy": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Description": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "Longer description of what the Stax VPC is used for.",
-								"example": "VPC for my particular application",
-								"maxLength": 2048,
-								"minLength": 0,
-								"type": "string"
-							}
-						]
-					},
-					"GatewayEndpoints": {
-						"items": {
-							"$ref": "#\/components\/schemas\/gateway-endpoint"
-						},
-						"type": "array"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of Stax VPC",
-						"example": "non-prod",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"NetworkingHubId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"PhzId": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The Route53 Private Hosted Zone Id for the VPC",
-								"example": "PHZAAEXAMPLE",
-								"type": "string"
-							}
-						]
-					},
-					"PhzPrefix": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
-								"example": "dev",
-								"type": "string"
-							}
-						]
-					},
-					"RedundantNat": {
-						"description": "Boolean value declaring if redundant NAT Gateways will be created",
-						"example": false,
-						"type": "boolean"
-					},
-					"Region": {
-						"$ref": "#\/components\/schemas\/AwsRegion"
-					},
-					"Size": {
-						"description": "Size of the VPC.",
-						"enum": [
-							"SMALL",
-							"MEDIUM",
-							"LARGE"
-						],
-						"example": "SMALL",
-						"type": "string"
-					},
-					"Status": {
-						"description": "The status of the Stax VPC.",
-						"enum": [
-							"ACTIVE",
-							"CREATE_IN_PROGRESS",
-							"CREATE_FAILED",
-							"DELETE_IN_PROGRESS",
-							"DELETED",
-							"DELETE_FAILED",
-							"UPDATE_IN_PROGRESS"
-						],
-						"example": "ACTIVE",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"Type": {
-						"description": "Type of VPC. The Type determines what Route Tables are attached to the VPC",
-						"enum": [
-							"FLAT",
-							"ISOLATED",
-							"SHAREDSERVICES",
-							"TRANSIT"
-						],
-						"example": "FLAT",
-						"type": "string"
-					},
-					"UserTaskId": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						]
-					},
-					"Zone": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "All 'Flat' VPCs in the same Zone can communicate to each other.",
-								"example": "non-prod",
-								"maxLength": 32,
-								"minLength": 2,
-								"type": "string"
-							}
-						]
-					}
-				},
-				"required": [
-					"Name",
-					"AccountId",
-					"Region"
-				],
-				"type": "object"
-			},
-			"Workload": {
-				"properties": {
-					"AccountId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"CatalogueId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"CatalogueVersionId": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"$ref": "#\/components\/schemas\/uuidv4"
-							}
-						]
-					},
-					"CreatedBy": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "The Workload name.",
-						"example": "my-workload-is-cool",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"Parameters": {
-						"$ref": "#\/components\/schemas\/Parameter"
-					},
-					"Protection": {
-						"description": "Boolean value declaring if the Workload is protected from deletion",
-						"example": false,
-						"type": "boolean"
-					},
-					"Region": {
-						"description": "AWS Region the workload will be launched in",
-						"example": "us-east-1",
-						"maxLength": 32,
-						"type": "string"
-					},
-					"Status": {
-						"description": "Status of the Workload.",
-						"enum": [
-							"NEW",
-							"INITIALIZING",
-							"ACTIVE",
-							"CREATE_FAILED",
-							"DELETE_IN_PROGRESS",
-							"DELETED",
-							"DELETE_FAILED",
-							"UPDATE_IN_PROGRESS",
-							"UPDATE_FAILED",
-							"UPDATE_COMPLETE"
-						],
-						"example": "NEW",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"UserTaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					}
-				},
-				"required": [
-					"Name",
-					"CatalogueId",
-					"AccountId",
-					"Region"
-				],
-				"type": "object"
-			},
-			"WorkloadCatalogue": {
-				"properties": {
-					"CatalogueVersionId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CreatedBy": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Description": {
-						"description": "Description of the Workload.",
-						"example": "A Workload to build a VPC in my org",
-						"maxLength": 1024,
-						"type": "string"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Workload Catalogue Item to create.",
-						"example": "my-directory-service",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"Protection": {
-						"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-						"example": false,
-						"type": "boolean"
-					},
-					"Public": {
-						"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-						"example": false,
-						"type": "boolean"
-					},
-					"Status": {
-						"description": "Status of the Workload.",
-						"enum": [
-							"NEW",
-							"UPLOADING",
-							"VALIDATING",
-							"ACTIVE",
-							"DELETED",
-							"FAILED"
-						],
-						"example": "NEW",
-						"readOnly": true,
-						"type": "string"
-					},
-					"UserTaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Versions": {
-						"items": {
-							"$ref": "#\/components\/schemas\/WorkloadCatalogueVersion"
-						},
-						"readOnly": true,
-						"type": "array"
-					}
-				},
-				"required": [
-					"Id",
-					"Versions"
-				]
-			},
-			"WorkloadCatalogueVersion": {
-				"properties": {
-					"CatalogueId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CreatedBy": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"CreatedTS": {
-						"description": "Created timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Description": {
-						"description": "Description of the Workload.",
-						"example": "A Workload to build a VPC in my org",
-						"maxLength": 1024,
-						"type": "string"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"ManifestURL": {
-						"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-						"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-						"type": "string"
-					},
-					"ModifiedTS": {
-						"description": "Modified timestamp.",
-						"example": "2018-10-11T01:05:45.000Z",
-						"format": "date-time",
-						"readOnly": true,
-						"type": "string"
-					},
-					"Outputs": {
-						"items": {
-							"example": "bread",
-							"type": "string"
-						},
-						"nullable": true,
-						"readOnly": true,
-						"type": "array"
-					},
-					"Parameters": {
-						"items": {
-							"$ref": "#\/components\/schemas\/Parameter"
-						},
-						"type": "array"
-					},
-					"Public": {
-						"description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
-						"example": false,
-						"type": "boolean"
-					},
-					"Status": {
-						"description": "Status of the Workload.",
-						"enum": [
-							"NEW",
-							"UPLOADING",
-							"VALIDATING",
-							"ACTIVE",
-							"DELETED",
-							"FAILED"
-						],
-						"example": "NEW",
-						"readOnly": true,
-						"type": "string"
-					},
-					"UserTaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"WorkloadVersion": {
-						"example": "0.01",
-						"readOnly": true,
-						"type": "string"
-					}
-				},
-				"required": [
-					"Id",
-					"Status",
-					"ManifestURL",
-					"WorkloadVersion"
-				],
-				"type": "object"
-			},
-			"WorkloadTask": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseTask"
-					}
-				],
-				"properties": {
-					"Workloads": {
-						"items": {
-							"$ref": "#\/components\/schemas\/ro-uuidv4"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"accounts.CreateAccount": {
-				"properties": {
-					"AccountType": {
-						"type": "string"
-					},
-					"AwsAccountId": {
-						"description": "AWS Account Id.",
-						"example": "012345678901",
-						"maxLength": 12,
-						"minLength": 12,
-						"readOnly": true,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Account.",
-						"example": "bakery",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name",
-					"AccountType"
-				],
-				"type": "object"
-			},
-			"accounts.CreateAccountType": {
-				"properties": {
-					"Name": {
-						"description": "Name of the Account Type.",
-						"example": "Development",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					}
-				},
-				"required": [
-					"Name"
-				],
-				"type": "object"
-			},
-			"accounts.CreateAccountTypeResponse": {
-				"properties": {
-					"Detail": {
-						"properties": {
-							"AccountType": {
-								"properties": {
-									"Accounts": {
-										"example": [],
-										"type": "array"
-									},
-									"CreatedBy": {
-										"$ref": "#\/components\/schemas\/ro-uuidv4"
-									},
-									"CreatedTS": {
-										"description": "Created timestamp.",
-										"example": "2018-10-11T01:05:45.000Z",
-										"format": "date-time",
-										"nullable": true,
-										"readOnly": true,
-										"type": "string"
-									},
-									"Id": {
-										"$ref": "#\/components\/schemas\/ro-uuidv4"
-									},
-									"ModifiedTS": {
-										"description": "Modified timestamp.",
-										"example": "2018-10-11T01:05:45.000Z",
-										"format": "date-time",
-										"nullable": true,
-										"readOnly": true,
-										"type": "string"
-									},
-									"Name": {
-										"example": "Development",
-										"type": "string"
-									},
-									"OrganisationId": {
-										"$ref": "#\/components\/schemas\/ro-uuidv4"
-									},
-									"Policies": {
-										"example": [],
-										"type": "array"
-									},
-									"Roles": {
-										"example": [],
-										"type": "array"
-									},
-									"Status": {
-										"enum": [
-											"ACTIVE",
-											"DELETED"
-										],
-										"example": "ACTIVE"
-									},
-									"StaxCreated": {
-										"type": "boolean"
-									}
-								},
-								"type": "object"
-							},
-							"Message": {
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OperationStatus": {
-								"$ref": "#\/components\/schemas\/OperationStatus"
-							},
-							"Severity": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"DetailType": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"Detail",
-					"DetailType"
-				],
-				"type": "object"
-			},
-			"accounts.DiscoverAccounts": {
-				"type": "object"
-			},
-			"accounts.DiscoverAccountsResponse": {
-				"allOf": [
-					{
-						"properties": {
-							"CustomerId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TaskId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TraceId": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					},
-					{
-						"properties": {
-							"Detail": {
-								"$ref": "#\/components\/schemas\/TraceEventDetail"
-							}
-						}
-					}
-				]
-			},
-			"accounts.OnboardAccount": {
-				"properties": {
-					"AccountType": {
-						"anyOf": [
-							{
-								"example": "Development",
-								"type": "string"
-							},
-							{
-								"$ref": "#\/components\/schemas\/uuidv4"
-							}
-						]
-					},
-					"AwsAccountId": {
-						"description": "AWS Account Id.",
-						"example": "012345678901",
-						"maxLength": 12,
-						"minLength": 12,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Account.",
-						"example": "bakery",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"AwsAccountId",
-					"AccountType"
-				],
-				"type": "object"
-			},
-			"accounts.ReadAccountTypes": {
-				"properties": {
-					"AccountTypes": {
-						"items": {
-							"$ref": "#\/components\/schemas\/AccountType"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"accounts.ReadAccounts": {
-				"properties": {
-					"Accounts": {
-						"items": {
-							"$ref": "#\/components\/schemas\/Account"
-						},
-						"type": "array"
-					},
-					"Paging": {
-						"$ref": "#\/components\/schemas\/Pagination"
-					}
-				},
-				"required": [
-					"Accounts"
-				],
-				"type": "object"
-			},
-			"accounts.UpdateAccount": {
-				"properties": {
-					"AccountType": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"Name": {
-						"description": "Name of the Account.",
-						"example": "bakery",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"type": "object"
-			},
-			"accounts.UpdateAccountResponse": {
-				"properties": {
-					"CustomerId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Detail": {
-						"properties": {
-							"Account": {
-								"properties": {
-									"AccountName": {
-										"example": "automation",
-										"type": "string"
-									},
-									"AccountType": {
-										"$ref": "#\/components\/schemas\/ro-uuidv4"
-									},
-									"Name": {
-										"example": "automation",
-										"type": "string"
-									},
-									"Operation": {
-										"$ref": "#\/components\/schemas\/Operation"
-									},
-									"OrganisationId": {
-										"$ref": "#\/components\/schemas\/ro-uuidv4"
-									},
-									"Tags": {
-										"$ref": "#\/components\/schemas\/Tags"
-									}
-								},
-								"type": "object"
-							},
-							"Message": {
-								"type": "string"
-							},
-							"Operation": {
-								"$ref": "#\/components\/schemas\/Operation"
-							},
-							"OperationStatus": {
-								"$ref": "#\/components\/schemas\/OperationStatus"
-							},
-							"Severity": {
-								"type": "string"
-							},
-							"TraceId": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					"DetailType": {
-						"type": "string"
-					},
-					"TaskId": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"TraceId": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"Detail",
-					"DetailType"
-				],
-				"type": "object"
-			},
-			"accounts.UpdateAccountType": {
-				"properties": {
-					"Name": {
-						"description": "Name of the Account Type.",
-						"example": "Development",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"accounts.UpdateAccountTypeAccess": {
-				"properties": {
-					"AddRoles": {
-						"example": [
-							{
-								"AccountTypeId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-								"GroupId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-								"RoleName": "admin"
-							}
-						],
-						"items": {
-							"$ref": "#\/components\/schemas\/AccountTypeAccessMap"
-						},
-						"type": "array"
-					},
-					"RemoveRoles": {
-						"example": [],
-						"items": {
-							"$ref": "#\/components\/schemas\/AccountTypeAccessMap"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"accounts.UpdateAccountTypeMembers": {
-				"properties": {
-					"Members": {
-						"example": [
-							{
-								"AccountId": "B4407766-E821-450D-B7C8-9EA38B58C432",
-								"AccountTypeId": "B4407766-E821-450D-B7C8-9EA38B58C432"
-							}
-						],
-						"items": {
-							"$ref": "#\/components\/schemas\/AccountTypeMemberMap"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"accounts.UpdatePolicies": {
-				"properties": {
-					"AddPolicies": {
-						"example": [
-							{
-								"AccountTypeId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-								"PolicyId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc"
-							}
-						],
-						"items": {
-							"$ref": "#\/components\/schemas\/AccountTypePolicyMap"
-						},
-						"type": "array"
-					},
-					"RemovePolicies": {
-						"example": [],
-						"items": {
-							"$ref": "#\/components\/schemas\/AccountTypePolicyMap"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"gateway-endpoint": {
-				"description": "A list of gateway vpc endpoints",
-				"enum": [
-					"dynamodb",
-					"s3"
-				],
-				"example": "s3",
-				"type": "string"
-			},
-			"interface-endpoint": {
-				"description": "A list of interface vpc endpoints",
-				"enum": [
-					"access-analyzer",
-					"application-autoscaling",
-					"appmesh-envoy-management",
-					"appstream.api",
-					"appstream.streaming",
-					"athena",
-					"autoscaling",
-					"autoscaling-plans",
-					"awsconnector",
-					"clouddirectory",
-					"cloudformation",
-					"cloudtrail",
-					"codebuild",
-					"codecommit",
-					"codepipeline",
-					"config",
-					"datasync",
-					"ec2",
-					"ec2messages",
-					"ecr.api",
-					"ecr.dkr",
-					"ecs",
-					"ecs-agent",
-					"ecs-telemetry",
-					"elasticfilesystem",
-					"elasticfilesystem-fips",
-					"elasticloadbalancing",
-					"events",
-					"execute-api",
-					"git-codecommit",
-					"glue",
-					"kinesis-firehose",
-					"kinesis-streams",
-					"kms",
-					"logs",
-					"monitoring",
-					"notebook",
-					"qldb.session",
-					"rekognition",
-					"sagemaker.api",
-					"sagemaker.runtime",
-					"secretsmanager",
-					"servicecatalog",
-					"sms",
-					"sns",
-					"sqs",
-					"ssm",
-					"ssmmessages",
-					"storagegateway",
-					"sts",
-					"transfer",
-					"transfer.server",
-					"workspaces"
-				],
-				"example": "ec2",
-				"type": "string"
-			},
-			"networking.CreateCidrExclusion": {
-				"additionalProperties": false,
-				"properties": {
-					"Cidr": {
-						"description": "CIDR Range in quad dot notation.",
-						"example": "10.128.0.0\/19",
-						"type": "string"
-					},
-					"Description": {
-						"description": "Longer description of what the CIDR Exclusion is used for.",
-						"example": "This Reservation blocks out existing legacy VPCs",
-						"maxLength": 2048,
-						"minLength": 0,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the CIDR Exclusion.",
-						"example": "legacy-vpcs",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name",
-					"Cidr"
-				],
-				"type": "object"
-			},
-			"networking.CreateCidrRange": {
-				"additionalProperties": false,
-				"properties": {
-					"Cidr": {
-						"description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
-						"example": "10.128.0.0\/23",
-						"type": "string"
-					},
-					"Description": {
-						"description": "Longer description of what the CIDR Range is used for.",
-						"example": "CIDR Range used for team ABCD application 1234",
-						"maxLength": 2048,
-						"minLength": 0,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the CIDR Range.",
-						"example": "prod",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name",
-					"Cidr"
-				],
-				"type": "object"
-			},
-			"networking.CreateDnsResolver": {
-				"additionalProperties": false,
-				"properties": {
-					"Name": {
-						"description": "Name of Stax DNS Resolver.",
-						"example": "dns",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"NumberOfInterfaces": {
-						"description": "The number of ENIs to attach to the Stax DNS Resolvers.",
-						"example": 2,
-						"type": "integer"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name",
-					"NumberOfInterfaces"
-				],
-				"type": "object"
-			},
-			"networking.CreateDnsRule": {
-				"additionalProperties": false,
-				"properties": {
-					"DomainName": {
-						"description": "Domain name to forward DNS queries for.",
-						"example": "test.local",
-						"maxLength": 128,
-						"minLength": 2,
-						"type": "string"
-					},
-					"ForwarderIpAddresses": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The IP Addresses to forward DNS queries to.",
-								"example": [
-									"192.168.0.1",
-									"192.168.0.2"
-								],
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"Name": {
-						"description": "Name of Stax DNS Rule.",
-						"example": "on-premises",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name",
-					"DomainName"
-				],
-				"type": "object"
-			},
-			"networking.CreateHub": {
-				"additionalProperties": false,
-				"properties": {
-					"AccountId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"AmazonSideAsn": {
-						"description": "A private Autonomous System Number (ASN) for the Amazon side of a BGP session",
-						"example": 64512,
-						"maximum": 65534,
-						"minimum": 64512,
-						"type": "integer"
-					},
-					"Cidr": {
-						"description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/22 for the Transit VPC",
-						"example": "10.128.0.0\/22",
-						"type": "string"
-					},
-					"CidrExclusions": {
-						"items": {
-							"$ref": "#\/components\/schemas\/CidrExclusion"
-						},
-						"type": "array"
-					},
-					"CidrRangeName": {
-						"description": "Name of the CIDR Range where the Transit VPC lives.",
-						"example": "myrange",
-						"maxLength": 64,
-						"minLength": 0,
-						"type": "string"
-					},
-					"CreateInternetGateway": {
-						"description": "Boolean value declaring to create an Internet Gateway",
-						"example": true,
-						"type": "boolean"
-					},
-					"CreateNatGateway": {
-						"description": "Boolean value declaring to create NAT Gateways",
-						"example": true,
-						"type": "boolean"
-					},
-					"Description": {
-						"description": "Longer description of what the Stax Networking Hub is used for.",
-						"example": "This Hub is for a team ABCD applications",
-						"maxLength": 2048,
-						"minLength": 0,
-						"type": "string"
-					},
-					"GatewayEndpoints": {
-						"items": {
-							"$ref": "#\/components\/schemas\/gateway-endpoint"
-						},
-						"type": "array"
-					},
-					"InterfaceEndpoints": {
-						"items": {
-							"$ref": "#\/components\/schemas\/interface-endpoint"
-						},
-						"type": "array"
-					},
-					"Name": {
-						"description": "Name of Stax Networking Hub.",
-						"example": "prod",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"PhzSuffix": {
-						"description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
-						"example": "my-domain.cloud",
-						"type": "string"
-					},
-					"Region": {
-						"$ref": "#\/components\/schemas\/AwsRegion"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name",
-					"AccountId",
-					"Region",
-					"Cidr",
-					"CreateNatGateway",
-					"CreateInternetGateway"
-				],
-				"type": "object"
-			},
-			"networking.CreateVpc": {
-				"additionalProperties": false,
-				"properties": {
-					"AccountId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"CidrRangeId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"CreateInternetGateway": {
-						"description": "Boolean value declaring to create an Internet Gateway",
-						"example": true,
-						"type": "boolean"
-					},
-					"Description": {
-						"description": "Longer description of what the Stax VPC is used for.",
-						"example": "VPC for a non-prod microservice",
-						"maxLength": 2048,
-						"minLength": 0,
-						"type": "string"
-					},
-					"GatewayEndpoints": {
-						"items": {
-							"$ref": "#\/components\/schemas\/gateway-endpoint"
-						},
-						"type": "array"
-					},
-					"Name": {
-						"description": "Name of Stax VPC",
-						"example": "dev-ms-customers",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"PhzPrefix": {
-						"description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
-						"example": "dev",
-						"type": "string"
-					},
-					"Region": {
-						"$ref": "#\/components\/schemas\/AwsRegion"
-					},
-					"Size": {
-						"description": "Size of the VPC.",
-						"enum": [
-							"SMALL",
-							"MEDIUM",
-							"LARGE"
-						],
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"Type": {
-						"description": "Type of VPC. The Type determines what Route Tables are attached to the VPC",
-						"enum": [
-							"ISOLATED",
-							"FLAT",
-							"SHAREDSERVICES"
-						],
-						"type": "string"
-					},
-					"Zone": {
-						"description": "All 'Flat' VPCs in the same Zone can communicate to each other.",
-						"example": "my-zone",
-						"maxLength": 64,
-						"minLength": 0,
-						"type": "string"
-					}
-				},
-				"required": [
-					"Name",
-					"CidrRangeId",
-					"AccountId",
-					"Region",
-					"Size",
-					"Type",
-					"CreateInternetGateway"
-				],
-				"type": "object"
-			},
-			"networking.ReadCidrExclusions": {
-				"additionalProperties": false,
-				"properties": {
-					"Exclusions": {
-						"items": {
-							"$ref": "#\/components\/schemas\/CidrExclusion"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"Exclusions"
-				],
-				"type": "object"
-			},
-			"networking.ReadCidrRanges": {
-				"additionalProperties": false,
-				"properties": {
-					"Ranges": {
-						"items": {
-							"$ref": "#\/components\/schemas\/CidrRange"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"Ranges"
-				],
-				"type": "object"
-			},
-			"networking.ReadDnsResolvers": {
-				"additionalProperties": false,
-				"properties": {
-					"DnsResolvers": {
-						"items": {
-							"$ref": "#\/components\/schemas\/DNSResolver"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"DnsResolvers"
-				],
-				"type": "object"
-			},
-			"networking.ReadDnsRules": {
-				"additionalProperties": false,
-				"properties": {
-					"DnsRules": {
-						"items": {
-							"$ref": "#\/components\/schemas\/DNSRule"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"DnsRules"
-				],
-				"type": "object"
-			},
-			"networking.ReadHubs": {
-				"additionalProperties": false,
-				"properties": {
-					"Hubs": {
-						"items": {
-							"$ref": "#\/components\/schemas\/NetworkingHub"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"Hubs"
-				],
-				"type": "object"
-			},
-			"networking.ReadVpcs": {
-				"additionalProperties": false,
-				"properties": {
-					"Vpcs": {
-						"items": {
-							"$ref": "#\/components\/schemas\/VPC"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"Vpcs"
-				],
-				"type": "object"
-			},
-			"networking.UpdateCidrExclusion": {
-				"additionalProperties": false,
-				"properties": {
-					"Description": {
-						"description": "Longer description of what the CIDR Exclusion is used for.",
-						"maxLength": 2048,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the CIDR Exclusion.",
-						"example": "data-center",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"type": "object"
-			},
-			"networking.UpdateCidrRange": {
-				"additionalProperties": false,
-				"properties": {
-					"Description": {
-						"description": "Longer description of what the CIDR Range is used for.",
-						"example": "CIDR Range used for team ABCD application 1234",
-						"maxLength": 2048,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the CIDR Range.",
-						"example": "prod",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"type": "object"
-			},
-			"networking.UpdateDnsResolver": {
-				"additionalProperties": false,
-				"properties": {
-					"Name": {
-						"description": "Name of Stax DNS Resolver.",
-						"example": "dns",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"NumberOfInterfaces": {
-						"description": "The number of ENIs to attach to the DNS Resolvers.",
-						"example": 2,
-						"type": "integer"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"type": "object"
-			},
-			"networking.UpdateDnsRule": {
-				"additionalProperties": false,
-				"properties": {
-					"ForwarderIpAddresses": {
-						"anyOf": [
-							{
-								"nullable": true
-							},
-							{
-								"description": "The IP Addresses to forward DNS queries to.",
-								"example": [
-									"192.168.0.1",
-									"192.168.0.2"
-								],
-								"items": {
-									"type": "string"
-								},
-								"type": "array"
-							}
-						]
-					},
-					"Name": {
-						"description": "Name of Stax DNS Rule.",
-						"example": "on-premises",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"type": "object"
-			},
-			"networking.UpdateHub": {
-				"additionalProperties": false,
-				"properties": {
-					"CreateInternetGateway": {
-						"description": "Boolean value declaring to create an Internet Gateway",
-						"example": true,
-						"type": "boolean"
-					},
-					"CreateNatGateway": {
-						"description": "Boolean value declaring to create NAT Gateways",
-						"example": true,
-						"type": "boolean"
-					},
-					"Description": {
-						"description": "Longer description of what the Stax Networking Hub is used for.",
-						"example": "This Hub is for connectivity from headquaters to VPC workloads",
-						"maxLength": 2048,
-						"type": "string"
-					},
-					"InterfaceEndpoints": {
-						"items": {
-							"$ref": "#\/components\/schemas\/interface-endpoint"
-						},
-						"type": "array"
-					},
-					"Name": {
-						"description": "Name of Stax Networking Hub",
-						"example": "prod",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"PhzSuffix": {
-						"description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
-						"example": "my-domain.cloud",
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"type": "object"
-			},
-			"networking.UpdateVpc": {
-				"additionalProperties": false,
-				"properties": {
-					"CreateInternetGateway": {
-						"description": "Boolean value declaring to create an Internet Gateway",
-						"example": true,
-						"type": "boolean"
-					},
-					"Description": {
-						"description": "Longer description of what this VPC is used for.",
-						"maxLength": 2048,
-						"type": "string"
-					},
-					"GatewayEndpoints": {
-						"items": {
-							"$ref": "#\/components\/schemas\/gateway-endpoint"
-						},
-						"type": "array"
-					},
-					"Name": {
-						"description": "Name of the Stax VPC",
-						"example": "prod",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"PhzPrefix": {
-						"description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
-						"example": "dev",
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"type": "object"
-			},
-			"organisations.AttachPolicy": {
-				"properties": {
-					"PolicyId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					}
-				},
-				"required": [
-					"PolicyId"
-				],
-				"type": "object"
-			},
-			"organisations.CreatePolicy": {
-				"properties": {
-					"Description": {
-						"description": "Description of the Policy.",
-						"example": "A service control policy that denies access to all.",
-						"maxLength": 1024,
-						"minLength": 3,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Policy.",
-						"example": "DenyAll",
-						"maxLength": 128,
-						"minLength": 3,
-						"type": "string"
-					},
-					"Policy": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"Name",
-					"Description",
-					"Policy"
-				],
-				"type": "object"
-			},
-			"organisations.ReadOrganisations": {
-				"properties": {
-					"Organisations": {
-						"items": {
-							"$ref": "#\/components\/schemas\/Organisation"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"organisations.ReadPolicies": {
-				"properties": {
-					"Policies": {
-						"items": {
-							"$ref": "#\/components\/schemas\/Policy"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"organisations.UpdatePolicy": {
-				"properties": {
-					"Description": {
-						"description": "Description of the Policy.",
-						"example": "A service control policy that denies access to all.",
-						"maxLength": 1024,
-						"minLength": 3,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Policy.",
-						"example": "DenyAll",
-						"maxLength": 128,
-						"minLength": 3,
-						"type": "string"
-					},
-					"Policy": {
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"ro-uuidv4": {
-				"example": "e893d7e0-9306-11e9-bc42-526af7764f64",
-				"pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-				"readOnly": true,
-				"type": "string"
-			},
-			"teams.CreateApiToken": {
-				"additionalProperties": false,
-				"properties": {
-					"Description": {
-						"description": "Longer description of what this Token is used for.",
-						"example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
-						"maxLength": 1024,
-						"minLength": 0,
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of API Token",
-						"example": "gitlab-cicd",
-						"maxLength": 64,
-						"minLength": 2,
-						"pattern": "^([0-9a-zA-Z_.-]+)$",
-						"type": "string"
-					},
-					"Role": {
-						"$ref": "#\/components\/schemas\/ApiRole"
-					},
-					"StoreToken": {
-						"default": true,
-						"description": "Store the Access and Secret key in SSM, in your security account.",
-						"example": true,
-						"type": "boolean"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"TokenKeyId": {
-						"default": "alias\/stax-api-tokens",
-						"description": "If you choose to store your keys in SSM, encrypt them with this KMS Key",
-						"example": "alias\/my-custom-key",
-						"maxLength": 128,
-						"minLength": 7,
-						"pattern": "^([a-zA-Z0-9:\/_-]+)$",
-						"type": "string"
-					}
-				},
-				"required": [
-					"Name",
-					"Role"
-				],
-				"type": "object"
-			},
-			"teams.CreateApiTokenResponse": {
-				"properties": {
-					"ApiTokens": {
-						"items": {
-							"properties": {
-								"AccessKey": {
-									"$ref": "#\/components\/schemas\/ro-uuidv4"
-								},
-								"CreatedBy": {
-									"$ref": "#\/components\/schemas\/ro-uuidv4"
-								},
-								"CreatedTS": {
-									"description": "Created timestamp.",
-									"example": "2018-10-11T01:05:45.000Z",
-									"format": "date-time",
-									"readOnly": true,
-									"type": "string"
-								},
-								"Description": {
-									"description": "Longer description of what this Token is used for.",
-									"example": "This token is for deployment pipelines in Gitlab to deploy to dev environments",
-									"maxLength": 1024,
-									"type": "string"
-								},
-								"Name": {
-									"description": "Name of API Token",
-									"example": "gitlab-cicd",
-									"maxLength": 64,
-									"minLength": 2,
-									"pattern": "^([0-9a-zA-Z_.-]+)$",
-									"type": "string"
-								},
-								"Role": {
-									"$ref": "#\/components\/schemas\/ApiRole"
-								},
-								"SecretKey": {
-									"maxLength": 32,
-									"minLength": 32,
-									"type": "string"
-								},
-								"Tags": {
-									"$ref": "#\/components\/schemas\/Tags"
-								}
-							},
-							"required": [
-								"AccessKey",
-								"SecretKey"
-							],
-							"type": "object"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"teams.CreateGroup": {
-				"properties": {
-					"Name": {
-						"description": "Name of User Group",
-						"example": "devops",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name"
-				],
-				"type": "object"
-			},
-			"teams.CreateGroupResponse": {
-				"allOf": [
-					{
-						"properties": {
-							"GroupId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							}
-						},
-						"type": "object"
-					},
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					},
-					{
-						"properties": {
-							"Detail": {
-								"$ref": "#\/components\/schemas\/TraceEventDetail"
-							}
-						}
-					}
-				]
-			},
-			"teams.CreateUser": {
-				"properties": {
-					"Email": {
-						"description": "Email address of User.",
-						"example": "stax.user@example.com",
-						"format": "email",
-						"maxLength": 128,
-						"minLength": 6,
-						"type": "string"
-					},
-					"FirstName": {
-						"description": "Given Name of the User.",
-						"example": "John",
-						"maxLength": 128,
-						"minLength": 0,
-						"type": "string"
-					},
-					"LastName": {
-						"description": "Family Name of the User.",
-						"example": "Doe",
-						"maxLength": 128,
-						"minLength": 0,
-						"type": "string"
-					},
-					"PhoneNumber": {
-						"description": "Phone number of User in E.164 format.",
-						"example": "+61491570006",
-						"pattern": "^\\+[1-9]\\d{4,14}$",
-						"type": "string"
-					},
-					"Role": {
-						"$ref": "#\/components\/schemas\/Role"
-					}
-				},
-				"required": [
-					"Email",
-					"FirstName",
-					"LastName"
-				],
-				"type": "object"
-			},
-			"teams.CreateUserResponse": {
-				"allOf": [
-					{
-						"properties": {
-							"CustomerId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TaskId": {
-								"$ref": "#\/components\/schemas\/ro-uuidv4"
-							},
-							"TraceId": {
-								"type": "string"
-							}
-						},
-						"type": "object"
-					},
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					},
-					{
-						"properties": {
-							"Detail": {
-								"$ref": "#\/components\/schemas\/TraceEventDetail"
-							}
-						}
-					}
-				]
-			},
-			"teams.InviteRootUser": {
-				"properties": {
-					"Email": {
-						"description": "Email address of User.",
-						"example": "stax.user@example.com",
-						"format": "email",
-						"maxLength": 128,
-						"minLength": 6,
-						"type": "string"
-					}
-				},
-				"required": [
-					"Email"
-				],
-				"type": "object"
-			},
-			"teams.ReadApiTokens": {
-				"properties": {
-					"ApiTokens": {
-						"items": {
-							"properties": {
-								"AccessKey": {
-									"$ref": "#\/components\/schemas\/ro-uuidv4"
-								},
-								"CreatedBy": {
-									"$ref": "#\/components\/schemas\/ro-uuidv4"
-								},
-								"CreatedTS": {
-									"description": "Created timestamp.",
-									"example": "2018-10-11T01:05:45.000Z",
-									"format": "date-time",
-									"readOnly": true,
-									"type": "string"
-								},
-								"Description": {
-									"description": "Longer description of what this Token is used for.",
-									"example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
-									"maxLength": 1024,
-									"minLength": 0,
-									"type": "string"
-								},
-								"ModifiedTS": {
-									"description": "Modified timestamp.",
-									"example": "2018-10-11T01:05:45.000Z",
-									"format": "date-time",
-									"readOnly": true,
-									"type": "string"
-								},
-								"Name": {
-									"description": "Name of API Token",
-									"example": "gitlab-cicd",
-									"maxLength": 64,
-									"minLength": 2,
-									"pattern": "^([0-9a-zA-Z_.-]+)$",
-									"type": "string"
-								},
-								"Role": {
-									"$ref": "#\/components\/schemas\/ApiRole"
-								},
-								"Status": {
-									"description": "Status of the Token.",
-									"enum": [
-										"ACTIVE",
-										"DELETED"
-									],
-									"example": "ACTIVE",
-									"type": "string"
-								},
-								"Tags": {
-									"$ref": "#\/components\/schemas\/Tags"
-								}
-							},
-							"type": "object"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"teams.ReadGroups": {
-				"properties": {
-					"Groups": {
-						"items": {
-							"$ref": "#\/components\/schemas\/Group"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"teams.ReadUsers": {
-				"properties": {
-					"Users": {
-						"items": {
-							"$ref": "#\/components\/schemas\/User"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"teams.UpdateApiToken": {
-				"properties": {
-					"Description": {
-						"description": "Longer description of what this Token is used for.",
-						"example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
-						"maxLength": 1024,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Role": {
-						"$ref": "#\/components\/schemas\/ApiRole"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"type": "object"
-			},
-			"teams.UpdateApiTokenResponse": {
-				"properties": {
-					"ApiTokens": {
-						"items": {
-							"properties": {
-								"AccessKey": {
-									"$ref": "#\/components\/schemas\/ro-uuidv4"
-								},
-								"CreatedBy": {
-									"$ref": "#\/components\/schemas\/ro-uuidv4"
-								},
-								"CreatedTS": {
-									"description": "Created timestamp.",
-									"example": "2018-10-11T01:05:45.000Z",
-									"format": "date-time",
-									"readOnly": true,
-									"type": "string"
-								},
-								"Description": {
-									"description": "Longer description of what this Token is used for.",
-									"example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
-									"maxLength": 1024,
-									"minLength": 0,
-									"type": "string"
-								},
-								"ModifiedTS": {
-									"description": "Modified timestamp.",
-									"example": "2018-10-11T01:05:45.000Z",
-									"format": "date-time",
-									"readOnly": true,
-									"type": "string"
-								},
-								"Name": {
-									"description": "Name of API Token",
-									"example": "gitlab-cicd",
-									"maxLength": 64,
-									"minLength": 2,
-									"pattern": "^([0-9a-zA-Z_.-]+)$",
-									"type": "string"
-								},
-								"Role": {
-									"$ref": "#\/components\/schemas\/ApiRole"
-								},
-								"Status": {
-									"description": "Status of the Token.",
-									"enum": [
-										"ACTIVE",
-										"DELETED"
-									],
-									"example": "ACTIVE",
-									"type": "string"
-								},
-								"Tags": {
-									"$ref": "#\/components\/schemas\/Tags"
-								}
-							},
-							"type": "object"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"teams.UpdateGroup": {
-				"properties": {
-					"Name": {
-						"description": "Name of User Group",
-						"example": "devops",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					}
-				},
-				"required": [
-					"Name"
-				],
-				"type": "object"
-			},
-			"teams.UpdateGroupMembers": {
-				"properties": {
-					"AddMembers": {
-						"items": {
-							"$ref": "#\/components\/schemas\/UserGroupMemberMap"
-						},
-						"type": "array"
-					},
-					"RemoveMembers": {
-						"items": {
-							"$ref": "#\/components\/schemas\/UserGroupMemberMap"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"teams.UpdateUser": {
-				"properties": {
-					"Email": {
-						"description": "Email address of User.",
-						"example": "stax.user@example.com",
-						"format": "email",
-						"maxLength": 128,
-						"minLength": 6,
-						"type": "string"
-					},
-					"FirstName": {
-						"description": "Given Name of the User.",
-						"example": "John",
-						"maxLength": 128,
-						"minLength": 0,
-						"type": "string"
-					},
-					"LastName": {
-						"description": "Family Name of the User.",
-						"example": "Doe",
-						"maxLength": 128,
-						"minLength": 0,
-						"type": "string"
-					},
-					"PhoneNumber": {
-						"description": "Phone number of User in E.164 format.",
-						"example": "+61491570006",
-						"pattern": "^\\+[1-9]\\d{4,14}$",
-						"type": "string"
-					},
-					"Role": {
-						"$ref": "#\/components\/schemas\/Role"
-					},
-					"Status": {
-						"description": "Status of User.",
-						"enum": [
-							"ACTIVE",
-							"DISABLED"
-						],
-						"type": "string"
-					}
-				},
-				"type": "object"
-			},
-			"teams.UpdateUserEvent": {
-				"allOf": [
-					{
-						"$ref": "#\/components\/schemas\/BaseEvent"
-					},
-					{
-						"properties": {
-							"Detail": {
-								"$ref": "#\/components\/schemas\/TraceEventDetail"
-							}
-						}
-					}
-				],
-				"type": "object"
-			},
-			"teams.UpdateUserInvite": {
-				"type": "object"
-			},
-			"teams.UpdateUserPassword": {
-				"type": "object"
-			},
-			"users.ReadIdamUsers": {
-				"properties": {
-					"Users": {
-						"items": {
-							"$ref": "#\/components\/schemas\/IdamUser"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"uuidv4": {
-				"example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
-				"pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
-				"type": "string"
-			},
-			"workloads.Catalogue": {
-				"properties": {
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"WorkloadCatalogueItems": {
-						"items": {
-							"$ref": "#\/components\/schemas\/WorkloadCatalogue"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"OrganisationId",
-					"WorkloadCatalogueItems"
-				],
-				"type": "object"
-			},
-			"workloads.CreateCatalogueItem": {
-				"properties": {
-					"Description": {
-						"description": "Description of the Workload.",
-						"example": "A Workload to build a VPC in my org",
-						"maxLength": 1024,
-						"type": "string"
-					},
-					"ManifestBody": {
-						"description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
-						"example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
-						"type": "string"
-					},
-					"ManifestURL": {
-						"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-						"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-						"type": "string"
-					},
-					"Name": {
-						"description": "Name of the Workload Catalogue Item to create.",
-						"example": "my-directory-service",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Parameters": {
-						"$ref": "#\/components\/schemas\/Parameter"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"Version": {
-						"description": "Version of the Workload Catalogue Item to create.",
-						"example": "1.0.2",
-						"maxLength": 128,
-						"type": "string"
-					}
-				},
-				"required": [
-					"Name",
-					"Version"
-				],
-				"type": "object"
-			},
-			"workloads.CreateCatalogueVersion": {
-				"properties": {
-					"Description": {
-						"description": "Description of the Workload.",
-						"example": "A Workload to build a VPC in my org",
-						"maxLength": 1024,
-						"type": "string"
-					},
-					"ManifestBody": {
-						"description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
-						"example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
-						"type": "string"
-					},
-					"ManifestURL": {
-						"description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
-						"example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
-						"type": "string"
-					},
-					"Parameters": {
-						"$ref": "#\/components\/schemas\/Parameter"
-					},
-					"Tags": {
-						"$ref": "#\/components\/schemas\/Tags"
-					},
-					"Version": {
-						"description": "Version of the Workload Catalogue Item to create.",
-						"example": "1.0.2",
-						"maxLength": 128,
-						"type": "string"
-					}
-				},
-				"required": [
-					"Version"
-				]
-			},
-			"workloads.CreateWorkload": {
-				"properties": {
-					"AccountId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"CatalogueId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"CatalogueVersionId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"Id": {
-						"$ref": "#\/components\/schemas\/ro-uuidv4"
-					},
-					"Name": {
-						"description": "The Workload name.",
-						"example": "my-workload-is-cool",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Parameters": {
-						"items": {
-							"$ref": "#\/components\/schemas\/Parameter"
-						},
-						"type": "array"
-					},
-					"Region": {
-						"description": "AWS Region the workload will be launched in",
-						"example": "us-east-1",
-						"maxLength": 32,
-						"type": "string"
-					},
-					"Tags": {
-						"anyOf": [
-							{
-								"type": "object"
-							},
-							{
-								"nullable": true
-							}
-						]
-					}
-				},
-				"required": [
-					"Name",
-					"CatalogueId",
-					"AccountId",
-					"Region"
-				],
-				"type": "object"
-			},
-			"workloads.ReadCatalogueItems": {
-				"properties": {
-					"OrganisationId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"WorkloadCatalogues": {
-						"items": {
-							"$ref": "#\/components\/schemas\/workloads.Catalogue"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"workloads.ReadCatalogueManifest": {
-				"properties": {
-					"url": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"url"
-				],
-				"type": "object"
-			},
-			"workloads.ReadCatalogueTemplate": {
-				"properties": {
-					"url": {
-						"type": "string"
-					}
-				},
-				"required": [
-					"url"
-				],
-				"type": "object"
-			},
-			"workloads.ReadCatalogueVersion": {
-				"properties": {
-					"Versions": {
-						"items": {
-							"$ref": "#\/components\/schemas\/WorkloadCatalogueVersion"
-						},
-						"type": "array"
-					}
-				},
-				"type": "object"
-			},
-			"workloads.ReadWorkloads": {
-				"properties": {
-					"Paging": {
-						"$ref": "#\/components\/schemas\/Pagination"
-					},
-					"Workloads": {
-						"items": {
-							"$ref": "#\/components\/schemas\/Workload"
-						},
-						"type": "array"
-					}
-				},
-				"required": [
-					"Workloads"
-				],
-				"type": "object"
-			},
-			"workloads.UpdateAll": {
-				"properties": {
-					"CatalogueId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"CatalogueVersionId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					}
-				},
-				"required": [
-					"CatalogueId"
-				],
-				"type": "object"
-			},
-			"workloads.UpdateWorkload": {
-				"properties": {
-					"CatalogueVersionId": {
-						"$ref": "#\/components\/schemas\/uuidv4"
-					},
-					"Name": {
-						"description": "The Workload name.",
-						"example": "my-workload-is-cool",
-						"maxLength": 64,
-						"minLength": 2,
-						"type": "string"
-					},
-					"Tags": {
-						"type": "object"
-					}
-				},
-				"type": "object"
-			}
-		},
-		"securitySchemes": {
-			"sigv4": {
-				"in": "header",
-				"name": "Authorization",
-				"type": "apiKey",
-				"x-amazon-apigateway-authtype": "awsSigv4"
-			}
-		}
-	},
-	"info": {
-		"contact": {
-			"url": "https:\/\/stax.io"
-		},
-		"description": "The Stax API is organised around REST, uses resource-oriented URLs, return responses are JSON and uses standard HTTP response codes, authentication and verbs.",
-		"termsOfService": "\/there_is_no_tos",
-		"title": "Stax Core API",
-		"version": "None"
-	},
-	"openapi": "3.0.0",
-	"paths": {
-		"\/20190206\/account-types\/members": {
-			"put": {
-				"description": "Move Accounts between Account Types.<br\/>",
-				"operationId": "accounts.UpdateAccountTypeMembers",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/accounts.UpdateAccountTypeMembers"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is forbidden."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Account Type members",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/account-types\/policies": {
-			"put": {
-				"description": "Add Policies to Account types or Remove Policies from Account Types.<br\/>",
-				"operationId": "accounts.UpdatePolicies",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/accounts.UpdatePolicies"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Account Type Policies",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/accounts": {
-			"get": {
-				"description": "Return all AWS Accounts within your Stax Organisation.<br\/>Optionally, return the requested AWS Account.<br\/>",
-				"operationId": "accounts.ReadAccounts",
-				"parameters": [
-					{
-						"description": "The UUID of the Account to return.",
-						"in": "path",
-						"name": "account_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The Account statuses to return, comma delimited.\n\nFilter options available: INITIALIZING, ACTIVE, SUSPENDED, MAINTENANCE, AWSERROR, CLOSED, OFFBOARDED, DISCOVERED, ERROR.\n",
-						"in": "query",
-						"name": "filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Account IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The Account Type IDs to return, comma delimited.\n",
-						"in": "query",
-						"name": "account_type_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Pagination - The page number to return.",
-						"in": "query",
-						"name": "offset",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "Pagination - The number of items per page to return.",
-						"in": "query",
-						"name": "limit",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "The field to sort on.",
-						"in": "query",
-						"name": "sort",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The sort order - up or down?",
-						"in": "query",
-						"name": "sort_order",
-						"required": false,
-						"schema": {
-							"default": "DESC",
-							"enum": [
-								"ASC",
-								"DESC"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "Do you want all the Tags?",
-						"in": "query",
-						"name": "include_tags",
-						"required": false,
-						"schema": {
-							"default": true,
-							"type": "boolean"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.ReadAccounts"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Accounts",
-				"tags": [
-					"Accounts"
-				]
-			},
-			"post": {
-				"description": "Create a new Stax-hardened AWS Account in your Stax Organisation.<br\/>",
-				"operationId": "accounts.CreateAccount",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/accounts.CreateAccount"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create Account",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/accounts\/discover": {
-			"post": {
-				"description": "Discover all AWS Accounts associated with the org into stax<br\/>Optionally attempt to rediscover an Aws Account that failed discovery<br\/>",
-				"operationId": "accounts.DiscoverAccounts",
-				"parameters": [
-					{
-						"description": "The AWS Account Id of the Account to discover.",
-						"in": "path",
-						"name": "aws_account_id",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.DiscoverAccountsResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful due to user input."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the account given has already been discovered."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the requested account cannot be discovered."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Discover Accounts",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/accounts\/discover\/{aws_account_id}": {
-			"post": {
-				"description": "Discover all AWS Accounts associated with the org into stax<br\/>Optionally attempt to rediscover an Aws Account that failed discovery<br\/>",
-				"operationId": "accounts.DiscoverAccounts",
-				"parameters": [
-					{
-						"description": "The AWS Account Id of the Account to discover.",
-						"in": "path",
-						"name": "aws_account_id",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.DiscoverAccountsResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful due to user input."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the account given has already been discovered."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the requested account cannot be discovered."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Discover Accounts",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/accounts\/onboard": {
-			"post": {
-				"description": "Onboard an existing AWS Account to your Stax Organisation.<br\/>",
-				"operationId": "accounts.OnboardAccount",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/accounts.OnboardAccount"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Onboard AWS Account",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/accounts\/types": {
-			"get": {
-				"description": "Return all the Account Types in your Stax Organisation.<br\/>Optionally, return the requested Account Type.<br\/>",
-				"operationId": "accounts.ReadAccountTypes",
-				"parameters": [
-					{
-						"description": "The UUID of the Account Type.",
-						"in": "path",
-						"name": "account_type_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of AccountType IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Account Types",
-				"tags": [
-					"Accounts"
-				]
-			},
-			"post": {
-				"description": "Create a new Account Type within your Stax Organisation.<br\/>Account Types can be used to set Policies on Accounts and control Group access.<br\/>",
-				"operationId": "accounts.CreateAccountType",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/accounts.CreateAccountType"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.CreateAccountTypeResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is forbidden."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create Account Type",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/accounts\/types\/access": {
-			"put": {
-				"description": "Adjust the AWS role permissions between Account Types and Groups.<br\/>",
-				"operationId": "accounts.UpdateAccountTypeAccess",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/accounts.UpdateAccountTypeAccess"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update AWS access",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/accounts\/types\/{account_type_id}": {
-			"delete": {
-				"description": "Delete an Account Type from your Stax Organisation.<br\/>An Account Type can only be deleted if there are no attached Accounts.<br\/>",
-				"operationId": "accounts.DeleteAccountType",
-				"parameters": [
-					{
-						"description": "The UUID of the Catalogue item.",
-						"in": "path",
-						"name": "account_type_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is forbidden."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete Account Type",
-				"tags": [
-					"Accounts"
-				]
-			},
-			"get": {
-				"description": "Return all the Account Types in your Stax Organisation.<br\/>Optionally, return the requested Account Type.<br\/>",
-				"operationId": "accounts.ReadAccountTypes",
-				"parameters": [
-					{
-						"description": "The UUID of the Account Type.",
-						"in": "path",
-						"name": "account_type_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of AccountType IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Account Types",
-				"tags": [
-					"Accounts"
-				]
-			},
-			"put": {
-				"description": "Change the details of an Account Type, such as the name.<br\/>",
-				"operationId": "accounts.UpdateAccountType",
-				"parameters": [
-					{
-						"description": "The UUID of the Account Type to update.",
-						"in": "path",
-						"name": "account_type_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/accounts.UpdateAccountType"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is forbidden."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Account Type",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/accounts\/{account_id}": {
-			"get": {
-				"description": "Return all AWS Accounts within your Stax Organisation.<br\/>Optionally, return the requested AWS Account.<br\/>",
-				"operationId": "accounts.ReadAccounts",
-				"parameters": [
-					{
-						"description": "The UUID of the Account to return.",
-						"in": "path",
-						"name": "account_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The Account statuses to return, comma delimited.\n\nFilter options available: INITIALIZING, ACTIVE, SUSPENDED, MAINTENANCE, AWSERROR, CLOSED, OFFBOARDED, DISCOVERED, ERROR.\n",
-						"in": "query",
-						"name": "filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Account IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The Account Type IDs to return, comma delimited.\n",
-						"in": "query",
-						"name": "account_type_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Pagination - The page number to return.",
-						"in": "query",
-						"name": "offset",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "Pagination - The number of items per page to return.",
-						"in": "query",
-						"name": "limit",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "The field to sort on.",
-						"in": "query",
-						"name": "sort",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The sort order - up or down?",
-						"in": "query",
-						"name": "sort_order",
-						"required": false,
-						"schema": {
-							"default": "DESC",
-							"enum": [
-								"ASC",
-								"DESC"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "Do you want all the Tags?",
-						"in": "query",
-						"name": "include_tags",
-						"required": false,
-						"schema": {
-							"default": true,
-							"type": "boolean"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.ReadAccounts"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Accounts",
-				"tags": [
-					"Accounts"
-				]
-			},
-			"put": {
-				"description": "Change the details of an Account, such as the name, tags or Account Type<br\/>",
-				"operationId": "accounts.UpdateAccount",
-				"parameters": [
-					{
-						"description": "The UUID of the Account to update.",
-						"in": "path",
-						"name": "account_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/accounts.UpdateAccount"
-							}
-						}
-					},
-					"required": false
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is forbidden."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Account",
-				"tags": [
-					"Accounts"
-				]
-			}
-		},
-		"\/20190206\/api-tokens": {
-			"get": {
-				"description": "Return a list of all API Tokens within your Stax Organisation.<br\/>",
-				"operationId": "teams.ReadApiTokens",
-				"parameters": [
-					{
-						"description": "The UUID of the Token to return.",
-						"in": "path",
-						"name": "AccessKey",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Access Keys you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: ACTIVE, DELETED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.ReadApiTokens"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch API Tokens",
-				"tags": [
-					"Team",
-					"Beta"
-				]
-			},
-			"post": {
-				"description": "Create an API Token for API\/SDK access within your Stax Organisation.<br\/>",
-				"operationId": "teams.CreateApiToken",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/teams.CreateApiToken"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.CreateApiTokenResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create API Token",
-				"tags": [
-					"Team",
-					"Beta"
-				]
-			}
-		},
-		"\/20190206\/api-tokens\/{AccessKey}": {
-			"delete": {
-				"description": "Delete an API Token from your Stax Organisation.<br\/>",
-				"operationId": "teams.DeleteApiToken",
-				"parameters": [
-					{
-						"description": "The UUID of the User to delete.",
-						"in": "path",
-						"name": "AccessKey",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.UpdateApiTokenResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete API Token",
-				"tags": [
-					"Team",
-					"Beta"
-				]
-			},
-			"get": {
-				"description": "Return a list of all API Tokens within your Stax Organisation.<br\/>",
-				"operationId": "teams.ReadApiTokens",
-				"parameters": [
-					{
-						"description": "The UUID of the Token to return.",
-						"in": "path",
-						"name": "AccessKey",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Access Keys you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: ACTIVE, DELETED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.ReadApiTokens"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch API Tokens",
-				"tags": [
-					"Team",
-					"Beta"
-				]
-			},
-			"put": {
-				"description": "Update a Token for API\/SDK access within your Stax Organisation.<br\/>",
-				"operationId": "teams.UpdateApiToken",
-				"parameters": [
-					{
-						"description": "The UUID of the API Token to update.",
-						"in": "path",
-						"name": "AccessKey",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/teams.UpdateApiToken"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.UpdateApiTokenResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update API Token",
-				"tags": [
-					"Team",
-					"Beta"
-				]
-			}
-		},
-		"\/20190206\/groups": {
-			"get": {
-				"description": "Return all Groups within your Stax Organisation.<br\/>Optionally, return the requested Group.<br\/>",
-				"operationId": "teams.ReadGroups",
-				"parameters": [
-					{
-						"description": "The UUID of the Group to return.",
-						"in": "path",
-						"name": "group_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Group IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.ReadGroups"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Groups",
-				"tags": [
-					"Groups"
-				]
-			},
-			"post": {
-				"description": "Create a new Group within your Stax Organisation.<br\/>",
-				"operationId": "teams.CreateGroup",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/teams.CreateGroup"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.CreateGroupResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create Group",
-				"tags": [
-					"Groups"
-				]
-			}
-		},
-		"\/20190206\/groups\/members": {
-			"put": {
-				"description": "Add members to a Group or Remove members from a Group<br\/>",
-				"operationId": "teams.UpdateGroupMembers",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/teams.UpdateGroupMembers"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "Could not locate user or group."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Group Members",
-				"tags": [
-					"Groups"
-				]
-			}
-		},
-		"\/20190206\/groups\/{group_id}": {
-			"delete": {
-				"description": "Delete a Group from your Stax Organisation.<br\/>A Group can only be deleted if there are no team members in the Group.<br\/>",
-				"operationId": "teams.DeleteGroup",
-				"parameters": [
-					{
-						"description": "The UUID of Group to delete.",
-						"in": "path",
-						"name": "group_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The Group still contains members."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The Group could not be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete Group",
-				"tags": [
-					"Groups"
-				]
-			},
-			"get": {
-				"description": "Return all Groups within your Stax Organisation.<br\/>Optionally, return the requested Group.<br\/>",
-				"operationId": "teams.ReadGroups",
-				"parameters": [
-					{
-						"description": "The UUID of the Group to return.",
-						"in": "path",
-						"name": "group_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Group IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.ReadGroups"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Groups",
-				"tags": [
-					"Groups"
-				]
-			},
-			"put": {
-				"description": "Change the details of a Group, such as the name.<br\/>",
-				"operationId": "teams.UpdateGroup",
-				"parameters": [
-					{
-						"description": "The UUID of the Group to update.",
-						"in": "path",
-						"name": "group_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/teams.UpdateGroup"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Group",
-				"tags": [
-					"Groups"
-				]
-			}
-		},
-		"\/20190206\/idam\/user": {
-			"get": {
-				"deprecated": true,
-				"description": "(DEPRECATED) Return a list of all IDAM Users in your Stax Organisation.<br\/>",
-				"operationId": "teams.ReadIdamUsers",
-				"parameters": [
-					{
-						"description": "The Organisation ID in which the IDAM is deployed to.  If no org_id is supplied, the Customer's default Organisation will be used.",
-						"in": "path",
-						"name": "org_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Do you want all the Tags?",
-						"in": "query",
-						"name": "include_tags",
-						"required": false,
-						"schema": {
-							"default": true,
-							"type": "boolean"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/users.ReadIdamUsers"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch IDAM Users",
-				"tags": [
-					"IDAM",
-					"Deprecated"
-				]
-			},
-			"post": {
-				"description": "Create a new Stax user within your Stax Organisation.<br\/>Stax Users have permission to access the AWS Console\/CLI for AWS Accounts that exist within a Stax Organisation.<br\/>",
-				"operationId": "teams.CreateUser",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/teams.CreateUser"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.CreateUserResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create Stax User",
-				"tags": [
-					"Team"
-				]
-			}
-		},
-		"\/20190206\/idam\/user\/resend-invite\/{user_id}": {
-			"put": {
-				"description": "Re-send the verification email for a Stax User.<br\/>",
-				"operationId": "teams.UpdateUserInvite",
-				"parameters": [
-					{
-						"description": "The UUID of the IDAM User to re-invite.",
-						"in": "path",
-						"name": "user_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.UpdateUserEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the user has already verified their email address."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the user does not exist in IDAM."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Re-invite Stax user",
-				"tags": [
-					"Team"
-				]
-			}
-		},
-		"\/20190206\/idam\/user\/reset-password\/{user_id}": {
-			"put": {
-				"description": "Send a Stax User a password reset email.<br\/>",
-				"operationId": "teams.UpdateUserPassword",
-				"parameters": [
-					{
-						"description": "The UUID of the IDAM User to have password reset.",
-						"in": "path",
-						"name": "user_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.UpdateUserEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the user has been deleted."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Reset Stax User's password",
-				"tags": [
-					"Team"
-				]
-			}
-		},
-		"\/20190206\/idam\/user\/{org_id}": {
-			"get": {
-				"deprecated": true,
-				"description": "(DEPRECATED) Return a list of all IDAM Users in your Stax Organisation.<br\/>",
-				"operationId": "teams.ReadIdamUsers",
-				"parameters": [
-					{
-						"description": "The Organisation ID in which the IDAM is deployed to.  If no org_id is supplied, the Customer's default Organisation will be used.",
-						"in": "path",
-						"name": "org_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Do you want all the Tags?",
-						"in": "query",
-						"name": "include_tags",
-						"required": false,
-						"schema": {
-							"default": true,
-							"type": "boolean"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/users.ReadIdamUsers"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch IDAM Users",
-				"tags": [
-					"IDAM",
-					"Deprecated"
-				]
-			}
-		},
-		"\/20190206\/idam\/user\/{user_id}": {
-			"put": {
-				"description": "Update a Stax User's details, such as the name, role or email.<br\/>",
-				"operationId": "teams.UpdateUser",
-				"parameters": [
-					{
-						"description": "The UUID of the IDAM User to update.",
-						"in": "path",
-						"name": "user_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/teams.UpdateUser"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.CreateUserResponse"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Stax User",
-				"tags": [
-					"Team"
-				]
-			}
-		},
-		"\/20190206\/networking\/dnsresolvers\/{dns_resolver_id}": {
-			"delete": {
-				"description": "<br\/>Deletes a Stax DNS Resolver within a Stax Networking Hub.<br\/>",
-				"operationId": "networking.DeleteDnsResolver",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax DNS Resolver to delete.",
-						"in": "path",
-						"name": "dns_resolver_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax Networking Hub doesn't match supplied credentials."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax DNS Resolver to delete cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete DNS Resolver",
-				"tags": [
-					"Beta"
-				]
-			},
-			"get": {
-				"description": "<br\/>Returns the DNS Resolver of the Stax Networking Hub.<br\/>Providing the UUID of a Stax DNS Resolver will return a specific Stax DNS Resolver's details.<br\/>",
-				"operationId": "networking.ReadDnsResolvers",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax Networking Hub where the Stax DNS Resolver is deployed.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Stax DNS Resolver to fetch.",
-						"in": "path",
-						"name": "dns_resolver_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Stax DNS Resolver statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadDnsResolvers"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch DNS Resolvers",
-				"tags": [
-					"Beta"
-				]
-			},
-			"put": {
-				"description": "<br\/>Updates the attributes for a given Stax DNS Resolver. Only supplied values are updated.<br\/>",
-				"operationId": "networking.UpdateDnsResolver",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax DNS Resolver to update.",
-						"in": "path",
-						"name": "dns_resolver_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.UpdateDnsResolver"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax Networking Hub doesn't match supplied credentials."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax DNS Resolver to update cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update DNS Resolver",
-				"tags": [
-					"Beta"
-				]
-			}
-		},
-		"\/20190206\/networking\/dnsresolvers\/{dns_resolver_id}\/dnsrules": {
-			"get": {
-				"description": "<br\/>Returns the Stax DNS Rules of the Stax DNS Resolver.<br\/>Providing the UUID of a Stax DNS Rule will return a specific Stax DNS Rule's details.<br\/>",
-				"operationId": "networking.ReadDnsRules",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax DNS Resolver.",
-						"in": "path",
-						"name": "dns_resolver_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Stax DNS Rule to fetch.",
-						"in": "path",
-						"name": "dns_rule_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Stax DNS Rule statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadDnsRules"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch DNS Rules",
-				"tags": [
-					"Beta"
-				]
-			},
-			"post": {
-				"description": "<br\/>Creates a Stax DNS Rule within a Stax DNS Resolver.<br\/>",
-				"operationId": "networking.CreateDnsRule",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax DNS Resolver to create the Stax DNS Rule within.",
-						"in": "path",
-						"name": "dns_resolver_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.CreateDnsRule"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax Networking Hub doesn't match supplied credentials."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax DNS Resolver to create the Stax DNS Rule within cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create DNS Rule",
-				"tags": [
-					"Beta"
-				]
-			}
-		},
-		"\/20190206\/networking\/dnsrules\/{dns_rule_id}": {
-			"delete": {
-				"description": "<br\/>Deletes a Stax DNS Rule within a Stax DNS Resolver<br\/>",
-				"operationId": "networking.DeleteDnsRule",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax DNS Rule.",
-						"in": "path",
-						"name": "dns_rule_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax Networking Hub doesn't match supplied credentials."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax DNS Rule to delete cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete DNS Rule",
-				"tags": [
-					"Beta"
-				]
-			},
-			"get": {
-				"description": "<br\/>Returns the Stax DNS Rules of the Stax DNS Resolver.<br\/>Providing the UUID of a Stax DNS Rule will return a specific Stax DNS Rule's details.<br\/>",
-				"operationId": "networking.ReadDnsRules",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax DNS Resolver.",
-						"in": "path",
-						"name": "dns_resolver_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Stax DNS Rule to fetch.",
-						"in": "path",
-						"name": "dns_rule_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Stax DNS Rule statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadDnsRules"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch DNS Rules",
-				"tags": [
-					"Beta"
-				]
-			},
-			"put": {
-				"description": "<br\/>Updates the attributes for a given Stax DNS Rule. Only supplied values are updated.<br\/>",
-				"operationId": "networking.UpdateDnsRule",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax DNS Rule to update.",
-						"in": "path",
-						"name": "dns_rule_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.UpdateDnsRule"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax Networking Hub doesn't match supplied credentials."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax DNS Rule to update cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update DNS Rule",
-				"tags": [
-					"Beta"
-				]
-			}
-		},
-		"\/20190206\/networking\/exclusions": {
-			"get": {
-				"description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
-				"operationId": "networking.ReadCidrExclusions",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub to list Exclusions in.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Exclusion to read.",
-						"in": "path",
-						"name": "exclusion_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch CIDR Exclusions",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/exclusions\/{exclusion_id}": {
-			"delete": {
-				"description": "<br\/>Deletes a CIDR Exclusion within a Stax Networking Hub.<br\/>",
-				"operationId": "networking.DeleteCidrExclusion",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub to delete the CIDR Exclusion.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Exclusion to Delete.",
-						"in": "path",
-						"name": "exclusion_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The CIDR Exclusion to delete cannot be found or is already deleted."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete CIDR Exclusion",
-				"tags": [
-					"Networking"
-				]
-			},
-			"get": {
-				"description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
-				"operationId": "networking.ReadCidrExclusions",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub to list Exclusions in.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Exclusion to read.",
-						"in": "path",
-						"name": "exclusion_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch CIDR Exclusions",
-				"tags": [
-					"Networking"
-				]
-			},
-			"put": {
-				"description": "<br\/>Updates a CIDR Exclusion within a Stax Networking Hub<br\/>",
-				"operationId": "networking.UpdateCidrExclusion",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub to update the CIDR Exclusion.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Exclusion to update.",
-						"in": "path",
-						"name": "exclusion_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.UpdateCidrExclusion"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.UpdateCidrExclusion"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The CIDR Exclusion to update cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update CIDR Exclusion",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/hubs": {
-			"get": {
-				"description": "<br\/>Returns a list of networking hubs in your Stax Organisation.<br\/>Can use the UUID of a Hub to return a specific hub details.<br\/>",
-				"operationId": "networking.ReadHubs",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, UPDATE_IN_PROGRESS, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadHubs"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Networking Hubs",
-				"tags": [
-					"Networking"
-				]
-			},
-			"post": {
-				"description": "<br\/>Creates Stax Networking Hub within your Stax Organisation.<br\/>",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.CreateHub"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The account to deploy a hub does not exist."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create Networking Hub",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/hubs\/{hub_id}": {
-			"delete": {
-				"description": "<br\/>Deletes a hub from the Stax Organisation<br\/>",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub to delete.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The hub to be deleted doesn't exist or is already deleted."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete Networking Hub",
-				"tags": [
-					"Networking"
-				]
-			},
-			"get": {
-				"description": "<br\/>Returns a list of networking hubs in your Stax Organisation.<br\/>Can use the UUID of a Hub to return a specific hub details.<br\/>",
-				"operationId": "networking.ReadHubs",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, UPDATE_IN_PROGRESS, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadHubs"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Networking Hubs",
-				"tags": [
-					"Networking"
-				]
-			},
-			"put": {
-				"description": "<br\/>Updates a various attributes for a given hub. Only supplied values are updated.<br\/>",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub to update.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.UpdateHub"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "An active hub to be updated does not exist"
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Networking Hub",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/hubs\/{hub_id}\/dnsresolvers": {
-			"get": {
-				"description": "<br\/>Returns the DNS Resolver of the Stax Networking Hub.<br\/>Providing the UUID of a Stax DNS Resolver will return a specific Stax DNS Resolver's details.<br\/>",
-				"operationId": "networking.ReadDnsResolvers",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax Networking Hub where the Stax DNS Resolver is deployed.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Stax DNS Resolver to fetch.",
-						"in": "path",
-						"name": "dns_resolver_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Stax DNS Resolver statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadDnsResolvers"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch DNS Resolvers",
-				"tags": [
-					"Beta"
-				]
-			},
-			"post": {
-				"description": "<br\/>Creates a Stax DNS Resolver within a Stax Networking Hub.<br\/>",
-				"operationId": "networking.CreateDnsResolver",
-				"parameters": [
-					{
-						"description": "The UUID of the Stax Networking Hub to deploy the Stax DNS Resolver.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.CreateDnsResolver"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Stax Networking Hub to deploy the Stax DNS Resolver cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create DNS Resolver",
-				"tags": [
-					"Beta"
-				]
-			}
-		},
-		"\/20190206\/networking\/hubs\/{hub_id}\/exclusions": {
-			"get": {
-				"description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
-				"operationId": "networking.ReadCidrExclusions",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub to list Exclusions in.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Exclusion to read.",
-						"in": "path",
-						"name": "exclusion_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch CIDR Exclusions",
-				"tags": [
-					"Networking"
-				]
-			},
-			"post": {
-				"description": "<br\/>Creates a CIDR Exclusion within a Stax Networking Hub<br\/>",
-				"operationId": "networking.CreateCidrExclusion",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub where the CIDR Exclusion is created in.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.CreateCidrExclusion"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The hub to create the CIDR Exclusion is not found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create CIDR Exclusion",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/hubs\/{hub_id}\/ranges": {
-			"get": {
-				"description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
-				"operationId": "networking.ReadCidrRanges",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub you want the Ranges for.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Range to read.",
-						"in": "path",
-						"name": "range_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch CIDR Ranges",
-				"tags": [
-					"Networking"
-				]
-			},
-			"post": {
-				"description": "<br\/>Creates a CIDR Range within a Stax Networking Hub<br\/>",
-				"operationId": "networking.CreateCidrRange",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub where the CIDR Range is created in.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.CreateCidrRange"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The hub to create the CIDR Range is not found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create CIDR Range",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/hubs\/{hub_id}\/vpcs": {
-			"get": {
-				"description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
-				"operationId": "networking.ReadVpcs",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub where the VPC is.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the VPC to read.",
-						"in": "path",
-						"name": "vpc_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-							"type": "string"
-						}
-					},
-					{
-						"description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
-						"in": "query",
-						"name": "type",
-						"required": false,
-						"schema": {
-							"default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadVpcs"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch VPCs",
-				"tags": [
-					"Networking"
-				]
-			},
-			"post": {
-				"description": "<br\/>Creates a VPC within a Stax Networking Hub<br\/>",
-				"operationId": "networking.CreateVpc",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub where the VPC is.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.CreateVpc"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "No permission to create VPC in the specified AWS Account"
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The hub to create the VPC is not found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create VPC",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/ranges": {
-			"get": {
-				"description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
-				"operationId": "networking.ReadCidrRanges",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub you want the Ranges for.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Range to read.",
-						"in": "path",
-						"name": "range_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch CIDR Ranges",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/ranges\/{range_id}": {
-			"delete": {
-				"description": "<br\/>Deletes a CIDR Range within a Stax Networking Hub. No existing VPCs can be in the CIDR Range.<br\/>",
-				"operationId": "networking.DeleteCidrRange",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub to delete the CIDR Range.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Range to delete.",
-						"in": "path",
-						"name": "range_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The CIDR Range to delete cannot be found or is already deleted."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete CIDR Range",
-				"tags": [
-					"Networking"
-				]
-			},
-			"get": {
-				"description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
-				"operationId": "networking.ReadCidrRanges",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub you want the Ranges for.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the Range to read.",
-						"in": "path",
-						"name": "range_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch CIDR Ranges",
-				"tags": [
-					"Networking"
-				]
-			},
-			"put": {
-				"description": "<br\/>Updates a CIDR Range within a Stax Networking Hub<br\/>",
-				"operationId": "networking.UpdateCidrRange",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub to update the CIDR Range.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the CIDR Range to update.",
-						"in": "path",
-						"name": "range_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.UpdateCidrRange"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.UpdateCidrRange"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The CIDR Range to update cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update CIDR Range",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/vpcs": {
-			"get": {
-				"description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
-				"operationId": "networking.ReadVpcs",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub where the VPC is.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the VPC to read.",
-						"in": "path",
-						"name": "vpc_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-							"type": "string"
-						}
-					},
-					{
-						"description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
-						"in": "query",
-						"name": "type",
-						"required": false,
-						"schema": {
-							"default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadVpcs"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch VPCs",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/networking\/vpcs\/{vpc_id}": {
-			"delete": {
-				"description": "<br\/>Deletes a VPC within a Stax Networking Hub<br\/>",
-				"operationId": "networking.DeleteVpc",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub where the VPC is.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the VPC to delete.",
-						"in": "path",
-						"name": "vpc_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The VPC to delete cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete VPC",
-				"tags": [
-					"Networking"
-				]
-			},
-			"get": {
-				"description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
-				"operationId": "networking.ReadVpcs",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub where the VPC is.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the VPC to read.",
-						"in": "path",
-						"name": "vpc_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
-						"in": "query",
-						"name": "status",
-						"required": false,
-						"schema": {
-							"default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
-							"type": "string"
-						}
-					},
-					{
-						"description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
-						"in": "query",
-						"name": "type",
-						"required": false,
-						"schema": {
-							"default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/networking.ReadVpcs"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch VPCs",
-				"tags": [
-					"Networking"
-				]
-			},
-			"put": {
-				"description": "<br\/>Updates a VPC within a Stax Networking Hub<br\/>",
-				"operationId": "networking.UpdateVpc",
-				"parameters": [
-					{
-						"description": "The UUID of the Hub where the VPC is.",
-						"in": "path",
-						"name": "hub_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					},
-					{
-						"description": "The UUID of the VPC to update.",
-						"in": "path",
-						"name": "vpc_id",
-						"required": true,
-						"schema": {
-							"$ref": "#\/components\/schemas\/uuidv4"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/networking.UpdateVpc"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The VPC to update cannot be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update VPC",
-				"tags": [
-					"Networking"
-				]
-			}
-		},
-		"\/20190206\/organisations": {
-			"get": {
-				"description": "Return a list of your Stax Organisations.<br\/>A Stax Organisation is an instance of Stax which houses your AWS Accounts, Workloads and IDAM Users.<br\/>",
-				"operationId": "organisations.ReadOrganisations",
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/organisations.ReadOrganisations"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful. The response body contains an Organisation array."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Stax Organisations",
-				"tags": [
-					"Organisations"
-				]
-			}
-		},
-		"\/20190206\/organisations\/current": {
-			"get": {
-				"description": "Return the current users Organisation.<br\/>A Stax Organisation is an instance of Stax which houses your AWS Accounts, Workloads and IDAM Users.<br\/>",
-				"operationId": "organisations.ReadOrganisation",
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/organisations.ReadOrganisations"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful. The response body contains an Organisation array."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Stax Organisations",
-				"tags": [
-					"Organisations"
-				]
-			}
-		},
-		"\/20190206\/policies": {
-			"get": {
-				"description": "Return all Policies in your Stax Organisation.<br\/>Optionally, return the requested Policy.<br\/>",
-				"operationId": "organisations.ReadPolicies",
-				"parameters": [
-					{
-						"description": "The UUID of the Policy to return.",
-						"in": "path",
-						"name": "policy_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/organisations.ReadPolicies"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Policies",
-				"tags": [
-					"Policies"
-				]
-			},
-			"post": {
-				"description": "Create a Policy in your Stax Organisation.<br\/>",
-				"operationId": "organisations.CreatePolicy",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/organisations.CreatePolicy"
-							}
-						}
-					},
-					"required": false
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/CreatePolicyEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create Policy",
-				"tags": [
-					"Policies"
-				]
-			}
-		},
-		"\/20190206\/policies\/organisation\/{policy_id}": {
-			"delete": {
-				"description": "Detach a Policy from your Stax Organisation.<br\/>The policy will no longer apply to all Account Types within the Organisation.<br\/>",
-				"operationId": "organisations:DetachPolicy",
-				"parameters": [
-					{
-						"description": "The UUID of the Policy to detach.",
-						"in": "path",
-						"name": "policy_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Detach Policy from Organisation",
-				"tags": [
-					"Policies"
-				]
-			},
-			"put": {
-				"description": "Attach a Policy to your Stax Organisation.<br\/>The policy will apply to all Account Types within the Organisation.<br\/>",
-				"operationId": "organisations:AttachPolicy",
-				"parameters": [
-					{
-						"description": "The UUID of the Policy to attach.",
-						"in": "path",
-						"name": "policy_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/organisations.AttachPolicy"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "Unable to attach foundation policy to an Organisation."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Attach Policy to Organisation",
-				"tags": [
-					"Policies"
-				]
-			}
-		},
-		"\/20190206\/policies\/{policy_id}": {
-			"delete": {
-				"description": "Delete a Policy from your Stax Organisation.<br\/>",
-				"operationId": "organisations.DeletePolicy",
-				"parameters": [
-					{
-						"description": "The UUID of the Policy to delete.",
-						"in": "path",
-						"name": "policy_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/DeletePolicyEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete Policy",
-				"tags": [
-					"Policies"
-				]
-			},
-			"get": {
-				"description": "Return all Policies in your Stax Organisation.<br\/>Optionally, return the requested Policy.<br\/>",
-				"operationId": "organisations.ReadPolicies",
-				"parameters": [
-					{
-						"description": "The UUID of the Policy to return.",
-						"in": "path",
-						"name": "policy_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/organisations.ReadPolicies"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Policies",
-				"tags": [
-					"Policies"
-				]
-			},
-			"put": {
-				"description": "Update an existing Policy within your Stax Organisation.<br\/>",
-				"operationId": "organisations.UpdatePolicy",
-				"parameters": [
-					{
-						"description": "The UUID of the Policy to update.",
-						"in": "path",
-						"name": "policy_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/organisations.UpdatePolicy"
-							}
-						}
-					},
-					"required": false
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/UpdatePolicyEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Policy",
-				"tags": [
-					"Policies"
-				]
-			}
-		},
-		"\/20190206\/public\/check-alias\/{alias}": {
-			"get": {
-				"description": "Check if an Alias is available or if it is already in use by another Stax customer.<br\/>The Alias is the unique identifier for a Customer's Stax Organisation.<br\/>",
-				"operationId": "public.CheckAlias",
-				"parameters": [
-					{
-						"description": "A unique string containing characters a-z, A-Z, 0-9.\nHyphens can also be used, but not at the start or end of the alias.\n",
-						"in": "path",
-						"name": "alias",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Alias"
-								}
-							}
-						},
-						"description": "The response returned if the Alias is available and not in use by another Customer."
-					},
-					"409": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/AliasInUse"
-								}
-							}
-						},
-						"description": "The Alias is already in use by another Customer."
-					}
-				},
-				"summary": "Check Alias availability",
-				"tags": [
-					"Public"
-				]
-			}
-		},
-		"\/20190206\/public\/config": {
-			"get": {
-				"description": "This is an unauthenticated endpoint returning your configuration variables which are required to authenticate API requests.<br\/>",
-				"operationId": "public.ReadConfig",
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Config"
-								}
-							}
-						},
-						"description": "Configuration values required to authenicate API requests."
-					}
-				},
-				"summary": "Fetch public config",
-				"tags": [
-					"Public"
-				]
-			}
-		},
-		"\/20190206\/task\/{task_id}": {
-			"get": {
-				"description": "Return the status of the requested Task.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
-				"operationId": "tasks.ReadTask",
-				"parameters": [
-					{
-						"description": "The UUID of the Task to return.",
-						"in": "path",
-						"name": "task_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Task"
-								}
-							}
-						},
-						"description": "The response returned for a valid Task."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the requested Task could not be found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch status of Task",
-				"tags": [
-					"Tasks"
-				]
-			}
-		},
-		"\/20190206\/tasks": {
-			"get": {
-				"description": "Return all Tasks for your Stax Organisation.<br\/>Optionally, return all tasks with the specified status for your Stax Organisation.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
-				"operationId": "tasks.ReadTasks",
-				"parameters": [
-					{
-						"description": "Return all tasks of this status.\n\nAccepted values are: RUNNING, SUCCEEDED or FAILED.\n",
-						"in": "path",
-						"name": "task_status",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/GetTasks"
-								}
-							}
-						},
-						"description": "The Tasks returned for a valid task_status."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The task_status not supplied or invalid."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch all Tasks by status",
-				"tags": [
-					"Tasks"
-				]
-			}
-		},
-		"\/20190206\/tasks\/{task_status}": {
-			"get": {
-				"description": "Return all Tasks for your Stax Organisation.<br\/>Optionally, return all tasks with the specified status for your Stax Organisation.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
-				"operationId": "tasks.ReadTasks",
-				"parameters": [
-					{
-						"description": "Return all tasks of this status.\n\nAccepted values are: RUNNING, SUCCEEDED or FAILED.\n",
-						"in": "path",
-						"name": "task_status",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/GetTasks"
-								}
-							}
-						},
-						"description": "The Tasks returned for a valid task_status."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The task_status not supplied or invalid."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch all Tasks by status",
-				"tags": [
-					"Tasks"
-				]
-			}
-		},
-		"\/20190206\/users": {
-			"get": {
-				"description": "Return a list of all Users within your Stax Organisation.<br\/>Optionally, return the requested User.<br\/>",
-				"operationId": "teams.ReadUsers",
-				"parameters": [
-					{
-						"description": "The UUID of the User to return.",
-						"in": "path",
-						"name": "user_id",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Users filtered by auth origin, comma delimited.\n\nFilter Options available: Team, Federated, Root\n",
-						"in": "query",
-						"name": "filter",
-						"required": false,
-						"schema": {
-							"default": "Team",
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of User IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Users filtered by Status, comma delimited.\n\nFilter Options available: ACTIVE, NEW, INVITED, DISABLED, DELETED\n",
-						"in": "query",
-						"name": "status_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.ReadUsers"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Stax Users, Federated Users, Root Users and API Tokens",
-				"tags": [
-					"Team"
-				]
-			}
-		},
-		"\/20190206\/users\/invite": {
-			"post": {
-				"description": "Invite a new Root User to your Stax Organisation.<br\/>",
-				"operationId": "teams.InviteRootUser",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/teams.InviteRootUser"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.ReadUsers"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "Only Root users can invite new Root users."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Invite New Root User",
-				"tags": [
-					"Team"
-				]
-			}
-		},
-		"\/20190206\/users\/me": {
-			"get": {
-				"description": "Returns the current logged in User.<br\/>",
-				"operationId": "teams.ReadUsers",
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.ReadUsers"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Current User",
-				"tags": [
-					"Team"
-				]
-			}
-		},
-		"\/20190206\/users\/{user_id}": {
-			"delete": {
-				"description": "Delete a Stax User from your Stax Organisation.<br\/>",
-				"operationId": "teams.DeleteUser",
-				"parameters": [
-					{
-						"description": "The UUID of the User to delete.",
-						"in": "path",
-						"name": "user_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.ReadUsers"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "User not found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete Stax User",
-				"tags": [
-					"Team"
-				]
-			},
-			"get": {
-				"description": "Return a list of all Users within your Stax Organisation.<br\/>Optionally, return the requested User.<br\/>",
-				"operationId": "teams.ReadUsers",
-				"parameters": [
-					{
-						"description": "The UUID of the User to return.",
-						"in": "path",
-						"name": "user_id",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Users filtered by auth origin, comma delimited.\n\nFilter Options available: Team, Federated, Root\n",
-						"in": "query",
-						"name": "filter",
-						"required": false,
-						"schema": {
-							"default": "Team",
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of User IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Users filtered by Status, comma delimited.\n\nFilter Options available: ACTIVE, NEW, INVITED, DISABLED, DELETED\n",
-						"in": "query",
-						"name": "status_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/teams.ReadUsers"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Stax Users, Federated Users, Root Users and API Tokens",
-				"tags": [
-					"Team"
-				]
-			}
-		},
-		"\/20190206\/workload-catalogue": {
-			"get": {
-				"description": "Return all Workload Catalogue Items within your Stax Organisation.<br\/>Optionally, return the requested Workload Catalogue Item.<br\/>",
-				"operationId": "workloads.ReadCatalogueItems",
-				"parameters": [
-					{
-						"description": "The UUID of the Catalogue Item to return.",
-						"in": "path",
-						"name": "catalogue_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The Name of the Workload Catalogue Items to return.",
-						"in": "query",
-						"name": "name",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload Catalogue Item statuses you want returned, comma delimited.\n\nFilter options available: STARTED, RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED.\n",
-						"in": "query",
-						"name": "filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload Catalogue Item IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Pagination - The page number to return.",
-						"in": "query",
-						"name": "offset",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "Pagination - The number of items per page to return.",
-						"in": "query",
-						"name": "limit",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "The field to sort on.",
-						"in": "query",
-						"name": "sort",
-						"required": false,
-						"schema": {
-							"enum": [
-								"Id",
-								"Name",
-								"Description",
-								"Status",
-								"OrganisationId",
-								"Public",
-								"CreatedTS",
-								"CreatedBy",
-								"ModifiedTS",
-								"UserTaskId",
-								"CatalogueVersionId",
-								"Protection"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "The sort order - up or down.",
-						"in": "query",
-						"name": "sort_order",
-						"required": false,
-						"schema": {
-							"default": "DESC",
-							"enum": [
-								"ASC",
-								"DESC"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "Do you want all Versions?",
-						"in": "query",
-						"name": "include_versions",
-						"required": false,
-						"schema": {
-							"default": true,
-							"type": "boolean"
-						}
-					},
-					{
-						"description": "Do you want the Parameter dictionary?",
-						"in": "query",
-						"name": "include_parameters",
-						"required": false,
-						"schema": {
-							"default": true,
-							"type": "boolean"
-						}
-					},
-					{
-						"description": "Do you want all the Tags?",
-						"in": "query",
-						"name": "include_tags",
-						"required": false,
-						"schema": {
-							"default": false,
-							"type": "boolean"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueItems"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if an invalid ID is entered."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if no catalogue is found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Workload Catalogue Items",
-				"tags": [
-					"Workloads"
-				]
-			},
-			"post": {
-				"description": "Create a new Workload Catalogue Item within your Stax Organisation.<br\/>",
-				"operationId": "workloads.CreateCatalogueItem",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/workloads.CreateCatalogueItem"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/CreateCatalogueEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Create Workload Catalogue Item",
-				"tags": [
-					"Workloads"
-				]
-			}
-		},
-		"\/20190206\/workload-catalogue\/manifest\/{version_id}": {
-			"get": {
-				"description": "Return a Workload Catalogue Manifest<br\/>",
-				"operationId": "workloads.ReadCatalogueManifest",
-				"parameters": [
-					{
-						"description": "The UUID of the Catalogue Version",
-						"in": "path",
-						"name": "version_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueManifest"
-								}
-							}
-						},
-						"description": "Returns the presigned url for the manifest file"
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if an invalid ID is entered."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is not successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Workload Catalogue Manifest",
-				"tags": [
-					"Workloads"
-				]
-			}
-		},
-		"\/20190206\/workload-catalogue\/template\/{version_id}\/{name}": {
-			"get": {
-				"description": "Return a specific Workload Catalogue Cloudformation Template<br\/>",
-				"operationId": "workloads.ReadCatalogueTemplate",
-				"parameters": [
-					{
-						"description": "The UUID of the Catalogue Version",
-						"in": "path",
-						"name": "version_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Retrieve the Cloudformation with this Resource Name.",
-						"in": "path",
-						"name": "name",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueTemplate"
-								}
-							}
-						},
-						"description": "Returns the presigned url to retrieve the template"
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if an invalid ID is entered."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is not successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Workload Catalogue Cloudformation Template",
-				"tags": [
-					"Workloads"
-				]
-			}
-		},
-		"\/20190206\/workload-catalogue\/{catalogue_id}": {
-			"delete": {
-				"description": "Delete a Workload Catalogue Item from your Stax Organisation.<br\/>Existing Workloads launched from this Catalogue will not be deleted.<br\/>",
-				"operationId": "workloads.DeleteCatalogueItem",
-				"parameters": [
-					{
-						"description": "The UUID of the Catalogue Item to delete.",
-						"in": "path",
-						"name": "catalogue_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/DeleteCatalogueEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Workload Catalogue can not be deleted due to running workloads."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Workload Catalogue is Protected. Protection must be disabled before you can delete it."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Workload Catalogue can not be found or does not belong to the user."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete Workload Catalogue Item",
-				"tags": [
-					"Workloads"
-				]
-			},
-			"get": {
-				"description": "Return all Workload Catalogue Items within your Stax Organisation.<br\/>Optionally, return the requested Workload Catalogue Item.<br\/>",
-				"operationId": "workloads.ReadCatalogueItems",
-				"parameters": [
-					{
-						"description": "The UUID of the Catalogue Item to return.",
-						"in": "path",
-						"name": "catalogue_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The Name of the Workload Catalogue Items to return.",
-						"in": "query",
-						"name": "name",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload Catalogue Item statuses you want returned, comma delimited.\n\nFilter options available: STARTED, RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED.\n",
-						"in": "query",
-						"name": "filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload Catalogue Item IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Pagination - The page number to return.",
-						"in": "query",
-						"name": "offset",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "Pagination - The number of items per page to return.",
-						"in": "query",
-						"name": "limit",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "The field to sort on.",
-						"in": "query",
-						"name": "sort",
-						"required": false,
-						"schema": {
-							"enum": [
-								"Id",
-								"Name",
-								"Description",
-								"Status",
-								"OrganisationId",
-								"Public",
-								"CreatedTS",
-								"CreatedBy",
-								"ModifiedTS",
-								"UserTaskId",
-								"CatalogueVersionId",
-								"Protection"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "The sort order - up or down.",
-						"in": "query",
-						"name": "sort_order",
-						"required": false,
-						"schema": {
-							"default": "DESC",
-							"enum": [
-								"ASC",
-								"DESC"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "Do you want all Versions?",
-						"in": "query",
-						"name": "include_versions",
-						"required": false,
-						"schema": {
-							"default": true,
-							"type": "boolean"
-						}
-					},
-					{
-						"description": "Do you want the Parameter dictionary?",
-						"in": "query",
-						"name": "include_parameters",
-						"required": false,
-						"schema": {
-							"default": true,
-							"type": "boolean"
-						}
-					},
-					{
-						"description": "Do you want all the Tags?",
-						"in": "query",
-						"name": "include_tags",
-						"required": false,
-						"schema": {
-							"default": false,
-							"type": "boolean"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueItems"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if an invalid ID is entered."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if no catalogue is found."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Workload Catalogue Items",
-				"tags": [
-					"Workloads"
-				]
-			},
-			"put": {
-				"description": "Creates a new version of a Workload Catalogue Item.<br\/>Workload Catalogue Items have one or more versions and are immutable, so any changes are a new version.<br\/>",
-				"operationId": "workloads.CreateCatalogueVersion",
-				"parameters": [
-					{
-						"description": "The UUID of the Catalogue Item to update.",
-						"in": "path",
-						"name": "catalogue_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/workloads.CreateCatalogueVersion"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/CreateVersionEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Workload Catalogue Item",
-				"tags": [
-					"Workloads"
-				]
-			}
-		},
-		"\/20190206\/workload-catalogue\/{catalogue_id}\/{version_id}": {
-			"delete": {
-				"description": "Delete a Workload Catalogue Version from your Stax Organisation.<br\/>Existing Workloads launched from this Workload Catalogue Version will not be deleted.<br\/>",
-				"operationId": "workloads.DeleteCatalogueVersion",
-				"parameters": [
-					{
-						"description": "The UUID of the Catalogue Item.",
-						"in": "path",
-						"name": "catalogue_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The UUID of the Catalogue Version to delete.",
-						"in": "path",
-						"name": "version_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/DeleteVersionEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Workload Catalogue Version can not be deleted due to running workloads."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Workload Catalogue Version can not be found or does not belong to the user."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Delete Workload Catalogue Version",
-				"tags": [
-					"Workloads"
-				]
-			},
-			"get": {
-				"description": "Return a specific Workload Catalogue Version.<br\/>",
-				"operationId": "workloads.ReadCatalogueVersion",
-				"parameters": [
-					{
-						"description": "The UUID of the Catalogue Item to return.",
-						"in": "path",
-						"name": "catalogue_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The UUID of the Catalogue Version to return.",
-						"in": "path",
-						"name": "version_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Do you want the Parameter dictionary?",
-						"in": "query",
-						"name": "include_parameters",
-						"required": false,
-						"schema": {
-							"default": true,
-							"type": "boolean"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/workloads.ReadCatalogueVersion"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if an invalid ID is entered."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is not successful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Workload Catalogue Version",
-				"tags": [
-					"Workloads"
-				]
-			}
-		},
-		"\/20190206\/workload-update": {
-			"post": {
-				"deprecated": true,
-				"description": "(DEPRECATED) Update all active Workloads for a specific Workload Catalogue Item.<br\/>",
-				"operationId": "workloads.UpdateAll",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/workloads.UpdateAll"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the Catalogue is not owned by the User."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update All Workloads",
-				"tags": [
-					"Workloads",
-					"Deprecated"
-				]
-			}
-		},
-		"\/20190206\/workloads": {
-			"get": {
-				"description": "Return a list of all Workloads available within your Stax Organisation.<br\/>Optionally, return the requested Workload.<br\/>",
-				"operationId": "workloads.ReadWorkloads",
-				"parameters": [
-					{
-						"description": "The UUID of the Workload Item to return.",
-						"in": "path",
-						"name": "workload_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The Name of the Workloads to return.",
-						"in": "query",
-						"name": "name",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: NEW, INITIALIZING, ACTIVE, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED, UPDATE_IN_PROGRESS, UPDATE_FAILED, UPDATE_COMPLETE.\n",
-						"in": "query",
-						"name": "filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Only return Workloads launched from this Catalogue Version.",
-						"in": "query",
-						"name": "catalogue_version_id",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Pagination - The page number to return. Must be used with limit",
-						"in": "query",
-						"name": "offset",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "Pagination - The number of items per page to return. Must be used with offset",
-						"in": "query",
-						"name": "limit",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "The field to sort on.",
-						"in": "query",
-						"name": "sort",
-						"required": false,
-						"schema": {
-							"enum": [
-								"Id",
-								"Name",
-								"AccountId",
-								"CatalogueId",
-								"CatalogueVersionId",
-								"Region",
-								"Status",
-								"UserTaskId",
-								"CreatedBy",
-								"CreatedTS",
-								"ModifiedTS",
-								"FactoryVersion"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "The sort order - up or down.",
-						"in": "query",
-						"name": "sort_order",
-						"required": false,
-						"schema": {
-							"default": "DESC",
-							"enum": [
-								"ASC",
-								"DESC"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "Do you want all the Tags?",
-						"in": "query",
-						"name": "include_tags",
-						"required": false,
-						"schema": {
-							"default": false,
-							"type": "boolean"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/workloads.ReadWorkloads"
-								}
-							}
-						},
-						"description": "A list of all Workloads for the logged in Customer."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the Workload ID is not a valid UUID."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the Workload ID does not exist."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Workloads",
-				"tags": [
-					"Workloads"
-				]
-			},
-			"post": {
-				"description": "Deploy a Workload within an AWS Account.<br\/>",
-				"operationId": "workloads.CreateWorkload",
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/Workload"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/CreateWorkloadEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Deploy Workload",
-				"tags": [
-					"Workloads"
-				]
-			}
-		},
-		"\/20190206\/workloads\/{workload_id}": {
-			"delete": {
-				"description": "Terminate an active Workload within an AWS Account.<br\/>",
-				"operationId": "workloads.DeleteWorkload",
-				"parameters": [
-					{
-						"description": "The UUID of the Workload to delete.",
-						"in": "path",
-						"name": "workload_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/DeleteWorkloadEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					},
-					"403": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The Workload is Protected. Protection must be disabled before you can delete it."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The Workload can not be found or does not belong to the user."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Terminate Workload",
-				"tags": [
-					"Workloads"
-				]
-			},
-			"get": {
-				"description": "Return a list of all Workloads available within your Stax Organisation.<br\/>Optionally, return the requested Workload.<br\/>",
-				"operationId": "workloads.ReadWorkloads",
-				"parameters": [
-					{
-						"description": "The UUID of the Workload Item to return.",
-						"in": "path",
-						"name": "workload_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "The Name of the Workloads to return.",
-						"in": "query",
-						"name": "name",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: NEW, INITIALIZING, ACTIVE, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED, UPDATE_IN_PROGRESS, UPDATE_FAILED, UPDATE_COMPLETE.\n",
-						"in": "query",
-						"name": "filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "List of Workload IDs you want returned, comma delimited.",
-						"in": "query",
-						"name": "id_filter",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Only return Workloads launched from this Catalogue Version.",
-						"in": "query",
-						"name": "catalogue_version_id",
-						"required": false,
-						"schema": {
-							"type": "string"
-						}
-					},
-					{
-						"description": "Pagination - The page number to return. Must be used with limit",
-						"in": "query",
-						"name": "offset",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "Pagination - The number of items per page to return. Must be used with offset",
-						"in": "query",
-						"name": "limit",
-						"required": false,
-						"schema": {
-							"type": "integer"
-						}
-					},
-					{
-						"description": "The field to sort on.",
-						"in": "query",
-						"name": "sort",
-						"required": false,
-						"schema": {
-							"enum": [
-								"Id",
-								"Name",
-								"AccountId",
-								"CatalogueId",
-								"CatalogueVersionId",
-								"Region",
-								"Status",
-								"UserTaskId",
-								"CreatedBy",
-								"CreatedTS",
-								"ModifiedTS",
-								"FactoryVersion"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "The sort order - up or down.",
-						"in": "query",
-						"name": "sort_order",
-						"required": false,
-						"schema": {
-							"default": "DESC",
-							"enum": [
-								"ASC",
-								"DESC"
-							],
-							"type": "string"
-						}
-					},
-					{
-						"description": "Do you want all the Tags?",
-						"in": "query",
-						"name": "include_tags",
-						"required": false,
-						"schema": {
-							"default": false,
-							"type": "boolean"
-						}
-					}
-				],
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/workloads.ReadWorkloads"
-								}
-							}
-						},
-						"description": "A list of all Workloads for the logged in Customer."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the Workload ID is not a valid UUID."
-					},
-					"404": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/Error"
-								}
-							}
-						},
-						"description": "The response returned if the Workload ID does not exist."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Fetch Workloads",
-				"tags": [
-					"Workloads"
-				]
-			},
-			"put": {
-				"description": "Update a Workload running within an AWS Account.<br\/>",
-				"operationId": "workloads.UpdateWorkload",
-				"parameters": [
-					{
-						"description": "The UUID of the Workload to update.",
-						"in": "path",
-						"name": "workload_id",
-						"required": true,
-						"schema": {
-							"type": "string"
-						}
-					}
-				],
-				"requestBody": {
-					"content": {
-						"application\/json": {
-							"schema": {
-								"$ref": "#\/components\/schemas\/workloads.UpdateWorkload"
-							}
-						}
-					},
-					"required": true
-				},
-				"responses": {
-					"200": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/UpdateWorkloadEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is successful."
-					},
-					"400": {
-						"content": {
-							"application\/json": {
-								"schema": {
-									"$ref": "#\/components\/schemas\/StaxEvent"
-								}
-							}
-						},
-						"description": "The response returned if the request is unsuccessful."
-					}
-				},
-				"security": [
-					{
-						"sigv4": []
-					}
-				],
-				"summary": "Update Workload",
-				"tags": [
-					"Workloads"
-				]
-			}
-		}
-	},
-	"servers": [
-		{
-			"url": "https:\/\/api.au1.staxapp.cloud"
-		}
-	]
+    "components": {
+        "requestBodies": {},
+        "responses": {},
+        "schemas": {
+            "Account": {
+                "properties": {
+                    "AWSLoginURLs": {
+                        "properties": {
+                            "admin": {"type": "string"},
+                            "developer": {"type": "string"},
+                            "readonly": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "AccountType": {"type": "string"},
+                    "AllocatedTS": {
+                        "description": "Allocated timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "AssuranceState": {
+                        "description": "Hardening state of the Account.",
+                        "enum": ["NONE", "UPDATING", "ACTIVE", "ERROR"],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "AssuranceStateReason": {
+                        "description": "Descriptive reason for the current AssuranceState.",
+                        "example": "AWS GuardDuty Hardening has failed",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "AwsAccountId": {
+                        "description": "AWS Account Id.",
+                        "example": "012345678901",
+                        "maxLength": 12,
+                        "minLength": 12,
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "AwsAccountStatusId": {"type": "string"},
+                    "AwsLoginURL": {"type": "string"},
+                    "CreatedBy": {
+                        "description": "UUID of the account creator.",
+                        "example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+                        "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Email": {
+                        "description": "Email address of account owner.",
+                        "example": "stax.user@example.com",
+                        "format": "email",
+                        "maxLength": 128,
+                        "minLength": 6,
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "LatestCost": {
+                        "example": 72.52,
+                        "readOnly": true,
+                        "type": "number",
+                    },
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2019-03-11T01:11:40.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Account.",
+                        "example": "bakery",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "OrgsOuId": {"type": "string"},
+                    "Origin": {
+                        "description": "Origin of the Account.",
+                        "enum": ["STAX", "External"],
+                        "example": "STAX",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Status": {
+                        "description": "Status of the Account.",
+                        "enum": [
+                            "ACTIVE",
+                            "AWSERROR",
+                            "CLOSED",
+                            "DISCOVERED",
+                            "ERROR",
+                            "INITIALIZING",
+                            "MAINTENANCE",
+                            "NEW",
+                            "NOAWS",
+                            "SUSPENDED",
+                        ],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "StaxCreated": {"type": "boolean"},
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "required": ["OrganisationId", "Name"],
+                "type": "object",
+            },
+            "AccountTask": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseTask"}],
+                "properties": {
+                    "Accounts": {
+                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "AccountType": {
+                "properties": {
+                    "Accounts": {"example": [], "type": "array"},
+                    "CreatedBy": {
+                        "description": "UUID of the account creator.",
+                        "example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+                        "nullable": true,
+                        "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of Account Type.",
+                        "example": "Development",
+                        "maxLength": 64,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Policies": {"example": [], "type": "array"},
+                    "Roles": {"example": [], "type": "array"},
+                    "Status": {"enum": ["ACTIVE", "DELETED"], "example": "ACTIVE"},
+                    "StaxCreated": {"type": "boolean"},
+                },
+                "required": ["OrganisationId", "Name"],
+                "type": "object",
+            },
+            "AccountTypeAccessMap": {
+                "additionalProperties": false,
+                "anyOf": [
+                    {"required": ["AccountTypeId", "GroupId", "RoleName"]},
+                    {"required": ["AccountTypeName", "GroupId", "RoleName"]},
+                    {"required": ["AccountTypeId", "GroupName", "RoleName"]},
+                    {"required": ["AccountTypeName", "GroupName", "RoleName"]},
+                ],
+                "properties": {
+                    "AccountTypeId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "AccountTypeName": {"type": "string"},
+                    "GroupId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "GroupName": {"type": "string"},
+                    "RoleName": {"$ref": "#\/components\/schemas\/AwsAccessRole"},
+                },
+                "type": "object",
+            },
+            "AccountTypeMemberMap": {
+                "additionalProperties": false,
+                "anyOf": [
+                    {"required": ["AccountTypeId", "AccountId"]},
+                    {"required": ["AccountTypeName", "AccountId"]},
+                ],
+                "properties": {
+                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "AccountTypeId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "AccountTypeName": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "AccountTypePolicyMap": {
+                "additionalProperties": false,
+                "anyOf": [
+                    {"required": ["AccountTypeId", "PolicyId"]},
+                    {"required": ["AccountTypeName", "PolicyId"]},
+                ],
+                "properties": {
+                    "AccountTypeId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "AccountTypeName": {"type": "string"},
+                    "PolicyId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                },
+                "type": "object",
+            },
+            "Alias": {
+                "properties": {
+                    "Alias": {
+                        "properties": {
+                            "Status": {
+                                "enum": [
+                                    "The company alias provided is available",
+                                    "The company alias provided is already in use by another customer and cannot be used",
+                                ],
+                                "example": "The company alias provided is available",
+                                "type": "string",
+                            }
+                        },
+                        "type": "object",
+                    }
+                },
+                "type": "object",
+            },
+            "AliasInUse": {
+                "properties": {
+                    "Alias": {
+                        "properties": {
+                            "Status": {
+                                "enum": [
+                                    "The company alias provided is available",
+                                    "The company alias provided is already in use by another customer and cannot be used",
+                                ],
+                                "example": "The company alias provided is already in use by another customer and cannot be used",
+                                "type": "string",
+                            }
+                        },
+                        "type": "object",
+                    }
+                },
+                "type": "object",
+            },
+            "ApiRole": {
+                "description": "Stax role assigned to an API Token.",
+                "enum": ["api_admin", "api_user", "api_readonly"],
+                "type": "string",
+            },
+            "AwsAccessRole": {
+                "description": "AWS access roles enabled for an account type.",
+                "enum": ["admin", "developer", "readonly"],
+                "type": "string",
+            },
+            "AwsRegion": {
+                "description": "AWS Region",
+                "enum": [
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-south-1",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ca-central-1",
+                    "eu-central-1",
+                    "eu-north-1",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2",
+                ],
+                "type": "string",
+            },
+            "BaseEvent": {
+                "properties": {"DetailType": {"type": "string"}},
+                "type": "object",
+            },
+            "BaseEventDetail": {
+                "properties": {
+                    "Message": {"type": "string"},
+                    "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                    "OperationStatus": {
+                        "$ref": "#\/components\/schemas\/OperationStatus"
+                    },
+                    "Severity": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "BaseTask": {
+                "properties": {
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Status": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "CidrExclusion": {
+                "additionalProperties": false,
+                "properties": {
+                    "Cidr": {
+                        "description": "CIDR Range in quad dot notation.",
+                        "example": "10.128.0.0\/19",
+                        "type": "string",
+                    },
+                    "CreatedBy": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Description": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "Longer description of what the CIDR Exclusion is used for.",
+                                "example": "datacenter exclusion",
+                                "maxLength": 512,
+                                "minLength": 0,
+                                "type": "string",
+                            },
+                        ]
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the CIDR Exclusion.",
+                        "example": "non-prod",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "NetworkingHubId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "Status": {
+                        "description": "The status of the CIRD Exclusion.",
+                        "enum": ["ACTIVE", "DELETED", "CREATE_FAILED", "DELETE_FAILED"],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["Name", "Cidr"],
+                "type": "object",
+            },
+            "CidrRange": {
+                "properties": {
+                    "Cidr": {
+                        "description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
+                        "example": "10.128.0.0\/23",
+                        "type": "string",
+                    },
+                    "CreatedBy": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "DefaultCidrRange": {
+                        "description": "Boolean value declaring if the range is the default CIDR Range",
+                        "example": false,
+                        "type": "boolean",
+                    },
+                    "Description": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "Longer description of what the CIDR Range is used for.",
+                                "example": "datacenter ranges",
+                                "maxLength": 512,
+                                "minLength": 0,
+                                "type": "string",
+                            },
+                        ]
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "LastAllocationTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the CIDR Range.",
+                        "example": "non-prod",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "NetworkingHubId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Status": {
+                        "description": "The status of the CIDR Range.",
+                        "enum": ["ACTIVE", "DELETED", "CREATE_FAILED", "DELETE_FAILED"],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["Name", "Cidr"],
+                "type": "object",
+            },
+            "Config": {
+                "properties": {
+                    "API": {
+                        "properties": {
+                            "endpoints": {
+                                "items": {
+                                    "$ref": "#\/components\/schemas\/ConfigEndpoint"
+                                },
+                                "type": "array",
+                            }
+                        },
+                        "type": "object",
+                    },
+                    "Analytics": {
+                        "properties": {"disable": {"type": "boolean"}},
+                        "type": "object",
+                    },
+                    "ApiAuth": {
+                        "properties": {
+                            "identityPoolId": {"type": "string"},
+                            "mandatorySignIn": {"type": "boolean"},
+                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                            "userPoolId": {"type": "string"},
+                            "userPoolWebClientId": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "AppSync": {
+                        "properties": {
+                            "analytics": {
+                                "properties": {
+                                    "endpoint": {"type": "string"},
+                                    "region": {
+                                        "$ref": "#\/components\/schemas\/AwsRegion"
+                                    },
+                                },
+                                "type": "object",
+                            },
+                            "core": {
+                                "properties": {
+                                    "endpoint": {"type": "string"},
+                                    "region": {
+                                        "$ref": "#\/components\/schemas\/AwsRegion"
+                                    },
+                                },
+                                "type": "object",
+                            },
+                            "graphqlEndpoint": {"type": "string"},
+                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                        },
+                        "type": "object",
+                    },
+                    "Auth": {
+                        "properties": {
+                            "identityPoolId": {"type": "string"},
+                            "mandatorySignIn": {"type": "boolean"},
+                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                            "userPoolId": {"type": "string"},
+                            "userPoolWebClientId": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "Juma": {
+                        "properties": {
+                            "controlplaneRegion": {"type": "string"},
+                            "domainName": {"type": "string"},
+                            "fullDomainName": {"type": "string"},
+                            "masterAccountId": {"type": "string"},
+                            "rootOrgId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "stage": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "JumaAuth": {
+                        "properties": {
+                            "identityPoolId": {"type": "string"},
+                            "mandatorySignIn": {"type": "boolean"},
+                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                            "userPoolId": {"type": "string"},
+                            "userPoolWebClientId": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "Pingdom": {
+                        "properties": {"key": {"nullable": true, "type": "string"}},
+                        "type": "object",
+                    },
+                    "SNS": {
+                        "properties": {
+                            "event": {"type": "string"},
+                            "notify": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "Sentry": {
+                        "properties": {
+                            "dsn": {"type": "string"},
+                            "projectName": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "Storage": {
+                        "properties": {
+                            "bucket": {"type": "string"},
+                            "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                        },
+                        "type": "object",
+                    },
+                    "Zone": {
+                        "properties": {"key": {"type": "string"}},
+                        "type": "object",
+                    },
+                },
+                "required": ["Auth", "API"],
+                "type": "object",
+            },
+            "ConfigEndpoint": {
+                "properties": {
+                    "endpoint": {"type": "string"},
+                    "name": {"type": "string"},
+                    "region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                },
+                "type": "object",
+            },
+            "CreateCatalogueDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "TraceId": {"type": "string"},
+                    "WorkloadCatalogueItem": {
+                        "properties": {
+                            "CatalogueId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "Description": {
+                                "description": "Description of the Workload.",
+                                "example": "A Workload to build a VPC in my org",
+                                "maxLength": 1024,
+                                "type": "string",
+                            },
+                            "ManifestURL": {
+                                "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+                                "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+                                "type": "string",
+                            },
+                            "Name": {
+                                "description": "Name of the Workload Catalogue Item to create.",
+                                "example": "my-directory-service",
+                                "maxLength": 64,
+                                "minLength": 2,
+                                "type": "string",
+                            },
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "Public": {
+                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+                                "example": false,
+                                "type": "boolean",
+                            },
+                            "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                            "Version": {
+                                "example": "0.01",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                        },
+                        "type": "object",
+                    },
+                },
+                "type": "object",
+            },
+            "CreateCatalogueEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Detail": {"$ref": "#\/components\/schemas\/CreateCatalogueDetail"},
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "TraceId": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "CreatePolicyDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "Policy": {
+                        "properties": {
+                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "Description": {
+                                "description": "Description of the Policy.",
+                                "example": "A service control policy that denies access to all.",
+                                "maxLength": 1024,
+                                "minLength": 3,
+                                "type": "string",
+                            },
+                            "Name": {
+                                "description": "Name of the Policy.",
+                                "example": "DenyAll",
+                                "maxLength": 128,
+                                "minLength": 3,
+                                "type": "string",
+                            },
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OrgId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "Policy": {"type": "string"},
+                            "PolicyId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TraceId": {"type": "string"},
+                        },
+                        "type": "object",
+                    }
+                },
+                "type": "object",
+            },
+            "CreatePolicyEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "Detail": {"$ref": "#\/components\/schemas\/CreatePolicyDetail"},
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "type": "object",
+            },
+            "CreateVersionDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "TraceId": {"type": "string"},
+                    "WorkloadCatalogueItem": {
+                        "properties": {
+                            "CatalogueId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "Description": {
+                                "description": "Description of the Workload.",
+                                "example": "A Workload to build a VPC in my org",
+                                "maxLength": 1024,
+                                "type": "string",
+                            },
+                            "ManifestBody": {
+                                "description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
+                                "example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
+                                "type": "string",
+                            },
+                            "ManifestURL": {
+                                "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+                                "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+                                "type": "string",
+                            },
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
+                            "Public": {
+                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+                                "example": false,
+                                "type": "boolean",
+                            },
+                            "Version": {
+                                "example": "0.01",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                        },
+                        "type": "object",
+                    },
+                },
+                "type": "object",
+            },
+            "CreateVersionEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Detail": {"$ref": "#\/components\/schemas\/CreateVersionDetail"},
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "TraceId": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "CreateWorkloadDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "Workload": {
+                        "properties": {
+                            "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "CatalogueId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "CatalogueVersionId": {
+                                "$ref": "#\/components\/schemas\/uuidv4"
+                            },
+                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "Name": {
+                                "description": "The Workload name.",
+                                "example": "my-workload-is-cool",
+                                "maxLength": 64,
+                                "minLength": 2,
+                                "type": "string",
+                            },
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OrgId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/uuidv4"
+                            },
+                            "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
+                            "Region": {
+                                "description": "AWS Region the workload will be launched in",
+                                "example": "us-east-1",
+                                "maxLength": 32,
+                                "type": "string",
+                            },
+                            "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                            "TaskId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "TraceId": {"type": "string"},
+                            "WorkloadId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                        },
+                        "type": "object",
+                    }
+                },
+                "type": "object",
+            },
+            "CreateWorkloadEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "Detail": {"$ref": "#\/components\/schemas\/CreateWorkloadDetail"},
+                    "WorkloadId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "type": "object",
+            },
+            "Customer": {
+                "properties": {
+                    "CognitoUserId": {
+                        "description": "Cognito User unique identifier.",
+                        "example": "my-user-id",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Email": {
+                        "description": "Email address of the User.",
+                        "example": "stax.user@example.com",
+                        "format": "email",
+                        "maxLength": 128,
+                        "minLength": 6,
+                        "type": "string",
+                    },
+                    "FactoryVersion": {"$ref": "#\/components\/schemas\/GitHash"},
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Account.",
+                        "example": "My Business",
+                        "maxLength": 64,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "Status": {
+                        "description": "Status of the Customer.",
+                        "enum": [
+                            "PROSPECT",
+                            "NEW",
+                            "INITIALIZING",
+                            "ACTIVE",
+                            "SUSPENDED",
+                        ],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "SupportPlan": {
+                        "description": "Stax Support Plan allocated to the Customer.",
+                        "enum": ["BASIC", "BUSINESS", "ENTERPRISE"],
+                        "example": "BUSINESS",
+                        "type": "string",
+                    },
+                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "required": ["Name", "Email"],
+                "type": "object",
+            },
+            "DNSResolver": {
+                "additionalProperties": false,
+                "properties": {
+                    "CreatedBy": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "InboundIpAddresses": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The IP Addresses attached to the Inbound DNS Resolver.",
+                                "example": ["192.168.0.1", "192.168.0.2"],
+                                "items": {"type": "string"},
+                                "type": "array",
+                            },
+                        ]
+                    },
+                    "Interfaces": {
+                        "description": "The number of ENIs to attach to the DNS Resolvers.",
+                        "example": 2,
+                        "type": "integer",
+                    },
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Stax DNS Resolvers.",
+                        "example": "dns",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "NetworkingHubId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "OutboundIpAddresses": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The IP Addresses attached to the Outbound DNS Resolver.",
+                                "example": ["192.168.0.1", "192.168.0.2"],
+                                "items": {"type": "string"},
+                                "type": "array",
+                            },
+                        ]
+                    },
+                    "Status": {
+                        "description": "The status of the Stax DNS Resolvers.",
+                        "enum": [
+                            "ACTIVE",
+                            "CREATE_IN_PROGRESS",
+                            "CREATE_FAILED",
+                            "DELETE_IN_PROGRESS",
+                            "DELETED",
+                            "DELETE_FAILED",
+                            "UPDATE_IN_PROGRESS",
+                        ],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "UserTaskId": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                },
+                "required": ["Name", "NetworkingHubId", "Interfaces"],
+                "type": "object",
+            },
+            "DNSRule": {
+                "additionalProperties": false,
+                "properties": {
+                    "AwsRuleId": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The AWS Route53 Resolver Rule Id.",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                        ]
+                    },
+                    "CreatedBy": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "DnsResolverId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "DomainName": {
+                        "description": "Domain name to forward DNS queries for.",
+                        "example": "test.local",
+                        "maxLength": 128,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "ForwarderIpAddresses": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The IP Addresses to forward DNS queries to.",
+                                "example": ["192.168.0.1", "192.168.0.2"],
+                                "items": {"type": "string"},
+                                "type": "array",
+                            },
+                        ]
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of Stax DNS Rule.",
+                        "example": "on-premises",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Status": {
+                        "description": "The status of the Stax DNS Rule.",
+                        "enum": [
+                            "ACTIVE",
+                            "CREATE_IN_PROGRESS",
+                            "CREATE_FAILED",
+                            "DELETE_IN_PROGRESS",
+                            "DELETED",
+                            "DELETE_FAILED",
+                            "UPDATE_IN_PROGRESS",
+                        ],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "UserTaskId": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                },
+                "required": ["Name", "DomainName", "DnsResolverId"],
+                "type": "object",
+            },
+            "DeleteCatalogueDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "AdditionalMetaData": {
+                        "properties": {
+                            "CatalogueVersionId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "CreatedTS": {
+                                "description": "Created timestamp.",
+                                "example": "2018-10-11T01:05:45.000Z",
+                                "format": "date-time",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                            "Description": {
+                                "description": "Description of the Workload.",
+                                "example": "A Workload to build a VPC in my org",
+                                "maxLength": 1024,
+                                "type": "string",
+                            },
+                            "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "ModifiedTS": {
+                                "description": "Modified timestamp.",
+                                "example": "2018-10-11T01:05:45.000Z",
+                                "format": "date-time",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                            "Name": {
+                                "description": "Name of the Workload Catalogue Item to create.",
+                                "example": "my-directory-service",
+                                "maxLength": 64,
+                                "minLength": 2,
+                                "type": "string",
+                            },
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/uuidv4"
+                            },
+                            "Protection": {
+                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+                                "example": false,
+                                "type": "boolean",
+                            },
+                            "Public": {
+                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+                                "example": false,
+                                "type": "boolean",
+                            },
+                            "Status": {
+                                "description": "Status of the Workload.",
+                                "enum": [
+                                    "NEW",
+                                    "UPLOADING",
+                                    "VALIDATING",
+                                    "ACTIVE",
+                                    "DELETED",
+                                    "FAILED",
+                                ],
+                                "example": "NEW",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                            "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        },
+                        "type": "object",
+                    },
+                    "TraceId": {"type": "string"},
+                    "WorkloadCatalogueItem": {
+                        "$ref": "#\/components\/schemas\/Operation"
+                    },
+                },
+                "type": "object",
+            },
+            "DeleteCatalogueEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Detail": {"$ref": "#\/components\/schemas\/DeleteCatalogueDetail"},
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "TraceId": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "DeletePolicyDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "Policy": {
+                        "properties": {
+                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OrgId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "PolicyId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TraceId": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "type": "object",
+            },
+            "DeletePolicyEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "Detail": {"$ref": "#\/components\/schemas\/DeletePolicyDetail"},
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "type": "object",
+            },
+            "DeleteVersionDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "AdditionalMetaData": {
+                        "properties": {
+                            "CatalogueId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "CreatedTS": {
+                                "description": "Created timestamp.",
+                                "example": "2018-10-11T01:05:45.000Z",
+                                "format": "date-time",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                            "Description": {
+                                "description": "Description of the Workload.",
+                                "example": "A Workload to build a VPC in my org",
+                                "maxLength": 1024,
+                                "type": "string",
+                            },
+                            "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "ManifestURL": {
+                                "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+                                "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+                                "type": "string",
+                            },
+                            "ModifiedTS": {
+                                "description": "Modified timestamp.",
+                                "example": "2018-10-11T01:05:45.000Z",
+                                "format": "date-time",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                            "Outputs": {
+                                "items": {"example": "bread", "type": "string"},
+                                "nullable": true,
+                                "readOnly": true,
+                                "type": "array",
+                            },
+                            "Public": {
+                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+                                "example": false,
+                                "type": "boolean",
+                            },
+                            "Status": {
+                                "description": "Status of the Workload.",
+                                "enum": [
+                                    "NEW",
+                                    "UPLOADING",
+                                    "VALIDATING",
+                                    "ACTIVE",
+                                    "DELETED",
+                                    "FAILED",
+                                ],
+                                "example": "NEW",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                            "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "WorkloadCatalogueName": {
+                                "description": "Name of the Workload Catalogue Item to create.",
+                                "example": "my-directory-service",
+                                "maxLength": 64,
+                                "minLength": 2,
+                                "type": "string",
+                            },
+                            "WorkloadVersion": {
+                                "example": "0.01",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                        },
+                        "type": "object",
+                    },
+                    "TraceId": {"type": "string"},
+                    "WorkloadCatalogueVersion": {
+                        "$ref": "#\/components\/schemas\/ro-uuidv4"
+                    },
+                },
+                "type": "object",
+            },
+            "DeleteVersionEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Detail": {"$ref": "#\/components\/schemas\/DeleteVersionDetail"},
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "TraceId": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "DeleteWorkloadDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "Workload": {
+                        "properties": {
+                            "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "CatalogueVersionId": {
+                                "$ref": "#\/components\/schemas\/uuidv4"
+                            },
+                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "Name": {
+                                "description": "The Workload name.",
+                                "example": "my-workload-is-cool",
+                                "maxLength": 64,
+                                "minLength": 2,
+                                "type": "string",
+                            },
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OrgId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/uuidv4"
+                            },
+                            "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
+                            "Region": {
+                                "description": "AWS Region the workload will be launched in",
+                                "example": "us-east-1",
+                                "maxLength": 32,
+                                "type": "string",
+                            },
+                            "TaskId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "TraceId": {"type": "string"},
+                            "WorkloadId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        },
+                        "type": "object",
+                    }
+                },
+                "type": "object",
+            },
+            "DeleteWorkloadEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "Detail": {"$ref": "#\/components\/schemas\/DeleteWorkloadDetail"}
+                },
+                "type": "object",
+            },
+            "Error": {
+                "properties": {
+                    "Cause": {"type": "string"},
+                    "Error": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "GetTasks": {
+                "properties": {"Tasks": {"$ref": "#\/components\/schemas\/Task"}},
+                "type": "object",
+            },
+            "GitHash": {
+                "example": "f8cf81b",
+                "maxLength": 7,
+                "minLength": 7,
+                "readOnly": true,
+                "type": "string",
+            },
+            "Group": {
+                "properties": {
+                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Group.",
+                        "example": "DevOps",
+                        "maxLength": 128,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Status": {
+                        "description": "Status of the Group.",
+                        "enum": ["ACTIVE", "DELETED"],
+                        "example": "ACTIVE",
+                        "type": "string",
+                    },
+                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Users": {
+                        "description": "Array of IDs of Users belonging to the Group.",
+                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        "type": "array",
+                    },
+                },
+                "required": ["Id", "Name"],
+                "type": "object",
+            },
+            "IdamUser": {
+                "properties": {"id": {"$ref": "#\/components\/schemas\/uuidv4"}},
+                "required": ["id"],
+                "type": "object",
+            },
+            "NetworkingHub": {
+                "additionalProperties": false,
+                "properties": {
+                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "Asn": {
+                        "description": "A private Autonomous System Number (ASN) for the Amazon side of a BGP session",
+                        "example": 64512,
+                        "type": "integer",
+                    },
+                    "CreatedBy": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Description": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "Longer description of what the Stax Networking Hub is used for.",
+                                "example": "my-hub",
+                                "maxLength": 512,
+                                "minLength": 0,
+                                "type": "string",
+                            },
+                        ]
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "InterfaceEndpoints": {
+                        "items": {"$ref": "#\/components\/schemas\/interface-endpoint"},
+                        "type": "array",
+                    },
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of Stax Networking Hub.",
+                        "example": "non-prod",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "PhzSuffix": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
+                                "example": "my-domain.cloud",
+                                "type": "string",
+                            },
+                        ]
+                    },
+                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                    "Status": {
+                        "description": "The status of the Stax Networking Hub.",
+                        "enum": [
+                            "ACTIVE",
+                            "CREATE_IN_PROGRESS",
+                            "CREATE_FAILED",
+                            "DELETE_IN_PROGRESS",
+                            "DELETED",
+                            "DELETE_FAILED",
+                            "UPDATE_IN_PROGRESS",
+                        ],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "UserTaskId": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                },
+                "required": ["Name", "AccountId", "Region"],
+                "type": "object",
+            },
+            "Operation": {
+                "enum": [
+                    "CREATE",
+                    "READ",
+                    "UPDATE",
+                    "DELETE",
+                    "accounts:CreateAccount",
+                    "accounts:CreateAccountType",
+                    "accounts:DiscoverAccounts",
+                    "accounts:DeleteAccountType",
+                    "accounts:ReadAccountTypes",
+                    "accounts:ReadAccounts",
+                    "accounts:UpdateAccount",
+                    "accounts:UpdateAccountType",
+                    "accounts:UpdateAccountTypeAccess",
+                    "accounts:UpdateAccountTypeMembers",
+                    "accounts:UpdatePolicies",
+                    "organisations:AttachPolicy",
+                    "organisations:CreatePolicy",
+                    "organisations:DeletePolicy",
+                    "organisations:DetachPolicy",
+                    "organisations:ReadPolicies",
+                    "organisations:UpdatePolicy",
+                    "teams:CreateApiToken",
+                    "teams:CreateGroup",
+                    "teams:CreateUser",
+                    "teams:DeleteApiToken",
+                    "teams:DeleteGroup",
+                    "teams:DeleteUser",
+                    "teams:ReadApiTokens",
+                    "teams:ReadGroups",
+                    "teams:ReadUsers",
+                    "teams:UpdateApiToken",
+                    "teams:UpdateGroup",
+                    "teams:UpdateGroupMembers",
+                    "teams:UpdateUser",
+                    "teams:UpdateUserPassword",
+                    "workloads:CreateCatalogueItem",
+                    "workloads:CreateCatalogueVersion",
+                    "workloads:CreateWorkload",
+                    "workloads:DeleteCatalogueItem",
+                    "workloads:DeleteCatalogueVersion",
+                    "workloads:DeleteWorkload",
+                    "workloads:ReadWorkloadCatalogueItems",
+                    "workloads:ReadWorkloads",
+                    "workloads:UpdateWorkload",
+                    "networking:CreateHub",
+                    "networking:UpdateHub",
+                    "networking:DeleteHub",
+                    "networking:CreateVpc",
+                    "networking:UpdateVpc",
+                    "networking:DeleteVpc",
+                    "networking:CreateDnsResolver",
+                    "networking:UpdateDnsResolver",
+                    "networking:DeleteDnsResolver",
+                    "networking:CreateDnsRule",
+                    "networking:UpdateDnsRule",
+                    "networking:DeleteDnsRule",
+                ],
+                "type": "string",
+            },
+            "OperationStatus": {
+                "enum": [
+                    "STARTED",
+                    "RUNNING",
+                    "SUCCEEDED",
+                    "FAILED",
+                    "TIMED_OUT",
+                    "ABORTED",
+                ],
+                "type": "string",
+            },
+            "Organisation": {
+                "properties": {
+                    "Alias": {
+                        "description": "Alias for your Organisation. This alias will be used in the URL of your Stax Identity Broker.",
+                        "example": "my-stax-org",
+                        "maxLength": 64,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "AllowedDomains": {
+                        "description": "Allowed email domains for the Organisation, this limits who can be invited to your Team.",
+                        "example": "@example.com,@stax.io",
+                        "maxLength": 64,
+                        "minLength": 3,
+                        "nullable": true,
+                        "type": "string",
+                    },
+                    "AttachedPolicies": {
+                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        "readOnly": true,
+                        "type": "array",
+                    },
+                    "AwsAccountEmailTemplate": {
+                        "description": "AWS Accounts will be registered with email addresses fitting this pattern. Please ensure these email addresses are secured, as they can be used for Root Credential recovery.",
+                        "example": "stax.user+${Stax::AccountId}@example.com",
+                        "maxLength": 64,
+                        "minLength": 3,
+                        "nullable": true,
+                        "type": "string",
+                    },
+                    "AwsPartnerSupport": {
+                        "description": "AWS Partner Led Support - if you have partner led support then Stax Support will open AWS Support cases on your behalf.",
+                        "type": "boolean",
+                    },
+                    "AwsSupportType": {
+                        "description": "Default AWS Support level set on Accounts in your Organisation.",
+                        "enum": ["BASIC", "DEVELOPER", "BUSINESS", "ENTERPRISE"],
+                        "example": "ENTERPRISE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "CreatedBy": {
+                        "anyOf": [
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            {"nullable": true},
+                        ]
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ExternalStaxId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Organisation",
+                        "example": "default",
+                        "maxLength": 64,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                    "SpotlightSsoURL": {"readOnly": true, "type": "string"},
+                    "Status": {
+                        "description": "Status of the Organisation.",
+                        "enum": ["NEW", "INITIALIZING", "ACTIVE", "SUSPENDED"],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "type": "object",
+            },
+            "Pagination": {
+                "description": "Pagination metadata. Present when limit and offset parameters are supplied.",
+                "properties": {
+                    "NextOffset": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "Offset value to provide to retrieve the next set of items. Null when there are no more pages to fetch.",
+                                "example": 20,
+                                "type": "number",
+                            },
+                        ]
+                    },
+                    "PrevOffset": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "Offset value to provide to retrieve the previous set of items. Null when the first page is returned.",
+                                "example": null,
+                                "type": "number",
+                            },
+                        ]
+                    },
+                    "Total": {
+                        "description": "Total number of items in the full pagination set after filters are applied.",
+                        "example": 100,
+                        "type": "number",
+                    },
+                },
+                "required": ["Total", "NextOffset", "PrevOffset"],
+                "type": "object",
+            },
+            "Parameter": {
+                "example": {"Key": "Bread", "Value": "Croissant"},
+                "nullable": true,
+                "properties": {
+                    "Key": {"maxLength": 255, "minLength": 1, "type": "string"},
+                    "Value": {
+                        "oneOf": [
+                            {"maxLength": 4096, "minLength": 1, "type": "string"},
+                            {"type": "integer"},
+                        ]
+                    },
+                },
+                "type": "object",
+            },
+            "Policy": {
+                "properties": {
+                    "AttachableTo": {
+                        "description": "Whether a policy is org only or account type only, or both",
+                        "enum": ["ORG", "ACCOUNT_TYPE", "ANY"],
+                        "example": "ANY",
+                        "readOnly": false,
+                        "type": "string",
+                    },
+                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Description": {
+                        "description": "Description of the Policy.",
+                        "example": "A service control policy that denies access to all.",
+                        "maxLength": 1024,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Mandatory": {
+                        "description": "Boolean value declaring if the policy is mandatory or not.",
+                        "example": false,
+                        "type": "boolean",
+                    },
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Policy.",
+                        "example": "DenyAll",
+                        "maxLength": 128,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Policy": {"type": "string"},
+                    "Public": {
+                        "description": "Boolean value declaring if the policy is public or private.",
+                        "example": false,
+                        "type": "boolean",
+                    },
+                    "Status": {
+                        "description": "Status of the policy.",
+                        "enum": ["ACTIVE", "DELETED", "FAILED"],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                },
+                "type": "object",
+            },
+            "Resource": {
+                "properties": {
+                    "ResourceId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ResourceType": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "Role": {
+                "description": "Stax role assigned to user.",
+                "enum": [
+                    "customer_root",
+                    "customer_admin",
+                    "customer_user",
+                    "customer_readonly",
+                ],
+                "example": "customer_admin",
+                "type": "string",
+            },
+            "StaxEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "Details": {"$ref": "#\/components\/schemas\/TaskEventDetail"}
+                },
+            },
+            "Tags": {
+                "anyOf": [
+                    {
+                        "additionalProperties": {"type": "string"},
+                        "maxProperties": 100,
+                        "minProperties": 1,
+                        "type": "object",
+                    },
+                    {"nullable": true},
+                ],
+                "example": {"CostCode": "12345"},
+            },
+            "Task": {"$ref": "#\/components\/schemas\/WorkloadTask"},
+            "TaskEventDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {"TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"}},
+            },
+            "TraceEventDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {"TraceId": {"type": "string"}},
+            },
+            "UpdateCatalogueDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "TraceId": {"type": "string"},
+                    "WorkloadCatalogueItem": {
+                        "properties": {
+                            "CatalogueId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "Description": {
+                                "description": "Description of the Workload.",
+                                "example": "A Workload to build a VPC in my org",
+                                "maxLength": 1024,
+                                "type": "string",
+                            },
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "Public": {
+                                "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+                                "example": false,
+                                "type": "boolean",
+                            },
+                            "Version": {
+                                "example": "0.01",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                        },
+                        "type": "object",
+                    },
+                },
+                "type": "object",
+            },
+            "UpdateCatalogueEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Detail": {"$ref": "#\/components\/schemas\/UpdateCatalogueDetail"},
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "TraceId": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "UpdatePolicyDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "Policy": {
+                        "properties": {
+                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "Name": {
+                                "description": "Name of the Policy.",
+                                "example": "DenyAll",
+                                "maxLength": 128,
+                                "minLength": 3,
+                                "type": "string",
+                            },
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OrgId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/ro-uuidv4"
+                            },
+                            "PolicyId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TraceId": {"type": "string"},
+                        },
+                        "type": "object",
+                    }
+                },
+                "type": "object",
+            },
+            "UpdatePolicyEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "Detail": {"$ref": "#\/components\/schemas\/UpdatePolicyDetail"},
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "type": "object",
+            },
+            "UpdateWorkloadDetail": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEventDetail"}],
+                "properties": {
+                    "Workload": {
+                        "properties": {
+                            "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "CatalogueVersionId": {
+                                "$ref": "#\/components\/schemas\/uuidv4"
+                            },
+                            "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "Name": {
+                                "description": "The Workload name.",
+                                "example": "my-workload-is-cool",
+                                "maxLength": 64,
+                                "minLength": 2,
+                                "type": "string",
+                            },
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OrgId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "OrganisationId": {
+                                "$ref": "#\/components\/schemas\/uuidv4"
+                            },
+                            "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
+                            "Region": {
+                                "description": "AWS Region the workload will be launched in",
+                                "example": "us-east-1",
+                                "maxLength": 32,
+                                "type": "string",
+                            },
+                            "TaskId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                            "TraceId": {"type": "string"},
+                            "WorkloadId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                        },
+                        "type": "object",
+                    }
+                },
+                "type": "object",
+            },
+            "UpdateWorkloadEvent": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseEvent"}],
+                "properties": {
+                    "Detail": {"$ref": "#\/components\/schemas\/UpdateWorkloadDetail"},
+                    "WorkloadId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "type": "object",
+            },
+            "User": {
+                "properties": {
+                    "AuthOrigin": {
+                        "example": "idam",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "CreatedBy": {
+                        "oneOf": [
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            {"nullable": true},
+                        ]
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "CustomerId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "Description": {
+                        "example": "Marketing User",
+                        "nullable": true,
+                        "type": "string",
+                    },
+                    "Email": {
+                        "description": "Email address of User.",
+                        "example": "stax.user@example.com",
+                        "format": "email",
+                        "maxLength": 128,
+                        "minLength": 6,
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "FirstName": {
+                        "oneOf": [
+                            {
+                                "description": "Given Name of the User.",
+                                "example": "John",
+                                "maxLength": 128,
+                                "minLength": 0,
+                                "type": "string",
+                            },
+                            {"nullable": true},
+                        ]
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "LastName": {
+                        "oneOf": [
+                            {
+                                "description": "Family Name of the User.",
+                                "example": "Doe",
+                                "maxLength": 128,
+                                "minLength": 0,
+                                "type": "string",
+                            },
+                            {"nullable": true},
+                        ]
+                    },
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Concatenation of first and last name. Defaults to email address if neither are present.",
+                        "example": "John Doe",
+                        "maxLength": 128,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "PhoneNumber": {
+                        "description": "Phone number of User in E.164 format.",
+                        "example": "+61491570006",
+                        "nullable": true,
+                        "pattern": "^\\+[1-9]\\d{4,14}$",
+                        "type": "string",
+                    },
+                    "Role": {"$ref": "#\/components\/schemas\/Role"},
+                    "Status": {
+                        "description": "Status of the User.",
+                        "enum": ["ACTIVE", "DISABLED", "DELETED", "INVITED", "NEW"],
+                        "example": "ACTIVE",
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "required": ["Id", "Email", "Name", "OrganisationId"],
+                "type": "object",
+            },
+            "UserGroupMemberMap": {
+                "additionalProperties": false,
+                "properties": {
+                    "GroupId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "UserId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                },
+                "type": "object",
+            },
+            "UserTask": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseTask"}],
+                "properties": {
+                    "Users": {
+                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "VPC": {
+                "additionalProperties": false,
+                "properties": {
+                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "AwsVpcId": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The AWS VPC ID.",
+                                "readOnly": true,
+                                "type": "string",
+                            },
+                        ]
+                    },
+                    "Cidr": {
+                        "description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
+                        "example": "10.128.0.0\/23",
+                        "type": "string",
+                    },
+                    "CidrRangeId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "CreateIgw": {
+                        "description": "Boolean value declaring if Internet Gateway is enabled",
+                        "example": true,
+                        "type": "boolean",
+                    },
+                    "CreateNat": {
+                        "description": "Boolean value declaring if NAT Gateways is enabled",
+                        "example": true,
+                        "type": "boolean",
+                    },
+                    "CreatedBy": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Description": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "Longer description of what the Stax VPC is used for.",
+                                "example": "VPC for my particular application",
+                                "maxLength": 2048,
+                                "minLength": 0,
+                                "type": "string",
+                            },
+                        ]
+                    },
+                    "GatewayEndpoints": {
+                        "items": {"$ref": "#\/components\/schemas\/gateway-endpoint"},
+                        "type": "array",
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of Stax VPC",
+                        "example": "non-prod",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "NetworkingHubId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "PhzId": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The Route53 Private Hosted Zone Id for the VPC",
+                                "example": "PHZAAEXAMPLE",
+                                "type": "string",
+                            },
+                        ]
+                    },
+                    "PhzPrefix": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
+                                "example": "dev",
+                                "type": "string",
+                            },
+                        ]
+                    },
+                    "RedundantNat": {
+                        "description": "Boolean value declaring if redundant NAT Gateways will be created",
+                        "example": false,
+                        "type": "boolean",
+                    },
+                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                    "Size": {
+                        "description": "Size of the VPC.",
+                        "enum": ["SMALL", "MEDIUM", "LARGE"],
+                        "example": "SMALL",
+                        "type": "string",
+                    },
+                    "Status": {
+                        "description": "The status of the Stax VPC.",
+                        "enum": [
+                            "ACTIVE",
+                            "CREATE_IN_PROGRESS",
+                            "CREATE_FAILED",
+                            "DELETE_IN_PROGRESS",
+                            "DELETED",
+                            "DELETE_FAILED",
+                            "UPDATE_IN_PROGRESS",
+                        ],
+                        "example": "ACTIVE",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "Type": {
+                        "description": "Type of VPC. The Type determines what Route Tables are attached to the VPC",
+                        "enum": ["FLAT", "ISOLATED", "SHAREDSERVICES", "TRANSIT"],
+                        "example": "FLAT",
+                        "type": "string",
+                    },
+                    "UserTaskId": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        ]
+                    },
+                    "Zone": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "All 'Flat' VPCs in the same Zone can communicate to each other.",
+                                "example": "non-prod",
+                                "maxLength": 32,
+                                "minLength": 2,
+                                "type": "string",
+                            },
+                        ]
+                    },
+                },
+                "required": ["Name", "AccountId", "Region"],
+                "type": "object",
+            },
+            "Workload": {
+                "properties": {
+                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "CatalogueId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "CatalogueVersionId": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {"$ref": "#\/components\/schemas\/uuidv4"},
+                        ]
+                    },
+                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "The Workload name.",
+                        "example": "my-workload-is-cool",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
+                    "Protection": {
+                        "description": "Boolean value declaring if the Workload is protected from deletion",
+                        "example": false,
+                        "type": "boolean",
+                    },
+                    "Region": {
+                        "description": "AWS Region the workload will be launched in",
+                        "example": "us-east-1",
+                        "maxLength": 32,
+                        "type": "string",
+                    },
+                    "Status": {
+                        "description": "Status of the Workload.",
+                        "enum": [
+                            "NEW",
+                            "INITIALIZING",
+                            "ACTIVE",
+                            "CREATE_FAILED",
+                            "DELETE_IN_PROGRESS",
+                            "DELETED",
+                            "DELETE_FAILED",
+                            "UPDATE_IN_PROGRESS",
+                            "UPDATE_FAILED",
+                            "UPDATE_COMPLETE",
+                        ],
+                        "example": "NEW",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                },
+                "required": ["Name", "CatalogueId", "AccountId", "Region"],
+                "type": "object",
+            },
+            "WorkloadCatalogue": {
+                "properties": {
+                    "CatalogueVersionId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Description": {
+                        "description": "Description of the Workload.",
+                        "example": "A Workload to build a VPC in my org",
+                        "maxLength": 1024,
+                        "type": "string",
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Workload Catalogue Item to create.",
+                        "example": "my-directory-service",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "Protection": {
+                        "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+                        "example": false,
+                        "type": "boolean",
+                    },
+                    "Public": {
+                        "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+                        "example": false,
+                        "type": "boolean",
+                    },
+                    "Status": {
+                        "description": "Status of the Workload.",
+                        "enum": [
+                            "NEW",
+                            "UPLOADING",
+                            "VALIDATING",
+                            "ACTIVE",
+                            "DELETED",
+                            "FAILED",
+                        ],
+                        "example": "NEW",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Versions": {
+                        "items": {
+                            "$ref": "#\/components\/schemas\/WorkloadCatalogueVersion"
+                        },
+                        "readOnly": true,
+                        "type": "array",
+                    },
+                },
+                "required": ["Id", "Versions"],
+            },
+            "WorkloadCatalogueVersion": {
+                "properties": {
+                    "CatalogueId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CreatedBy": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "CreatedTS": {
+                        "description": "Created timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Description": {
+                        "description": "Description of the Workload.",
+                        "example": "A Workload to build a VPC in my org",
+                        "maxLength": 1024,
+                        "type": "string",
+                    },
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "ManifestURL": {
+                        "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+                        "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+                        "type": "string",
+                    },
+                    "ModifiedTS": {
+                        "description": "Modified timestamp.",
+                        "example": "2018-10-11T01:05:45.000Z",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Outputs": {
+                        "items": {"example": "bread", "type": "string"},
+                        "nullable": true,
+                        "readOnly": true,
+                        "type": "array",
+                    },
+                    "Parameters": {
+                        "items": {"$ref": "#\/components\/schemas\/Parameter"},
+                        "type": "array",
+                    },
+                    "Public": {
+                        "description": "Boolean value declaring if the Workload Catalogue Item is public or private.",
+                        "example": false,
+                        "type": "boolean",
+                    },
+                    "Status": {
+                        "description": "Status of the Workload.",
+                        "enum": [
+                            "NEW",
+                            "UPLOADING",
+                            "VALIDATING",
+                            "ACTIVE",
+                            "DELETED",
+                            "FAILED",
+                        ],
+                        "example": "NEW",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "UserTaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "WorkloadVersion": {
+                        "example": "0.01",
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                },
+                "required": ["Id", "Status", "ManifestURL", "WorkloadVersion"],
+                "type": "object",
+            },
+            "WorkloadTask": {
+                "allOf": [{"$ref": "#\/components\/schemas\/BaseTask"}],
+                "properties": {
+                    "Workloads": {
+                        "items": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "accounts.CreateAccount": {
+                "properties": {
+                    "AccountType": {"type": "string"},
+                    "AwsAccountId": {
+                        "description": "AWS Account Id.",
+                        "example": "012345678901",
+                        "maxLength": 12,
+                        "minLength": 12,
+                        "readOnly": true,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Account.",
+                        "example": "bakery",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["Name", "AccountType"],
+                "type": "object",
+            },
+            "accounts.CreateAccountType": {
+                "properties": {
+                    "Name": {
+                        "description": "Name of the Account Type.",
+                        "example": "Development",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    }
+                },
+                "required": ["Name"],
+                "type": "object",
+            },
+            "accounts.CreateAccountTypeResponse": {
+                "properties": {
+                    "Detail": {
+                        "properties": {
+                            "AccountType": {
+                                "properties": {
+                                    "Accounts": {"example": [], "type": "array"},
+                                    "CreatedBy": {
+                                        "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                    },
+                                    "CreatedTS": {
+                                        "description": "Created timestamp.",
+                                        "example": "2018-10-11T01:05:45.000Z",
+                                        "format": "date-time",
+                                        "nullable": true,
+                                        "readOnly": true,
+                                        "type": "string",
+                                    },
+                                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                                    "ModifiedTS": {
+                                        "description": "Modified timestamp.",
+                                        "example": "2018-10-11T01:05:45.000Z",
+                                        "format": "date-time",
+                                        "nullable": true,
+                                        "readOnly": true,
+                                        "type": "string",
+                                    },
+                                    "Name": {
+                                        "example": "Development",
+                                        "type": "string",
+                                    },
+                                    "OrganisationId": {
+                                        "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                    },
+                                    "Policies": {"example": [], "type": "array"},
+                                    "Roles": {"example": [], "type": "array"},
+                                    "Status": {
+                                        "enum": ["ACTIVE", "DELETED"],
+                                        "example": "ACTIVE",
+                                    },
+                                    "StaxCreated": {"type": "boolean"},
+                                },
+                                "type": "object",
+                            },
+                            "Message": {"type": "string"},
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OperationStatus": {
+                                "$ref": "#\/components\/schemas\/OperationStatus"
+                            },
+                            "Severity": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "DetailType": {"type": "string"},
+                },
+                "required": ["Detail", "DetailType"],
+                "type": "object",
+            },
+            "accounts.DiscoverAccounts": {"type": "object"},
+            "accounts.DiscoverAccountsResponse": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TraceId": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    {"$ref": "#\/components\/schemas\/BaseEvent"},
+                    {
+                        "properties": {
+                            "Detail": {
+                                "$ref": "#\/components\/schemas\/TraceEventDetail"
+                            }
+                        }
+                    },
+                ]
+            },
+            "accounts.OnboardAccount": {
+                "properties": {
+                    "AccountType": {
+                        "anyOf": [
+                            {"example": "Development", "type": "string"},
+                            {"$ref": "#\/components\/schemas\/uuidv4"},
+                        ]
+                    },
+                    "AwsAccountId": {
+                        "description": "AWS Account Id.",
+                        "example": "012345678901",
+                        "maxLength": 12,
+                        "minLength": 12,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Account.",
+                        "example": "bakery",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["AwsAccountId", "AccountType"],
+                "type": "object",
+            },
+            "accounts.ReadAccountTypes": {
+                "properties": {
+                    "AccountTypes": {
+                        "items": {"$ref": "#\/components\/schemas\/AccountType"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "accounts.ReadAccounts": {
+                "properties": {
+                    "Accounts": {
+                        "items": {"$ref": "#\/components\/schemas\/Account"},
+                        "type": "array",
+                    },
+                    "Paging": {"$ref": "#\/components\/schemas\/Pagination"},
+                },
+                "required": ["Accounts"],
+                "type": "object",
+            },
+            "accounts.UpdateAccount": {
+                "properties": {
+                    "AccountType": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "Name": {
+                        "description": "Name of the Account.",
+                        "example": "bakery",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "type": "object",
+            },
+            "accounts.UpdateAccountResponse": {
+                "properties": {
+                    "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Detail": {
+                        "properties": {
+                            "Account": {
+                                "properties": {
+                                    "AccountName": {
+                                        "example": "automation",
+                                        "type": "string",
+                                    },
+                                    "AccountType": {
+                                        "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                    },
+                                    "Name": {"example": "automation", "type": "string"},
+                                    "Operation": {
+                                        "$ref": "#\/components\/schemas\/Operation"
+                                    },
+                                    "OrganisationId": {
+                                        "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                    },
+                                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                                },
+                                "type": "object",
+                            },
+                            "Message": {"type": "string"},
+                            "Operation": {"$ref": "#\/components\/schemas\/Operation"},
+                            "OperationStatus": {
+                                "$ref": "#\/components\/schemas\/OperationStatus"
+                            },
+                            "Severity": {"type": "string"},
+                            "TraceId": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    "DetailType": {"type": "string"},
+                    "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "TraceId": {"type": "string"},
+                },
+                "required": ["Detail", "DetailType"],
+                "type": "object",
+            },
+            "accounts.UpdateAccountType": {
+                "properties": {
+                    "Name": {
+                        "description": "Name of the Account Type.",
+                        "example": "Development",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    }
+                },
+                "type": "object",
+            },
+            "accounts.UpdateAccountTypeAccess": {
+                "properties": {
+                    "AddRoles": {
+                        "example": [
+                            {
+                                "AccountTypeId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+                                "GroupId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+                                "RoleName": "admin",
+                            }
+                        ],
+                        "items": {
+                            "$ref": "#\/components\/schemas\/AccountTypeAccessMap"
+                        },
+                        "type": "array",
+                    },
+                    "RemoveRoles": {
+                        "example": [],
+                        "items": {
+                            "$ref": "#\/components\/schemas\/AccountTypeAccessMap"
+                        },
+                        "type": "array",
+                    },
+                },
+                "type": "object",
+            },
+            "accounts.UpdateAccountTypeMembers": {
+                "properties": {
+                    "Members": {
+                        "example": [
+                            {
+                                "AccountId": "B4407766-E821-450D-B7C8-9EA38B58C432",
+                                "AccountTypeId": "B4407766-E821-450D-B7C8-9EA38B58C432",
+                            }
+                        ],
+                        "items": {
+                            "$ref": "#\/components\/schemas\/AccountTypeMemberMap"
+                        },
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "accounts.UpdatePolicies": {
+                "properties": {
+                    "AddPolicies": {
+                        "example": [
+                            {
+                                "AccountTypeId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+                                "PolicyId": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+                            }
+                        ],
+                        "items": {
+                            "$ref": "#\/components\/schemas\/AccountTypePolicyMap"
+                        },
+                        "type": "array",
+                    },
+                    "RemovePolicies": {
+                        "example": [],
+                        "items": {
+                            "$ref": "#\/components\/schemas\/AccountTypePolicyMap"
+                        },
+                        "type": "array",
+                    },
+                },
+                "type": "object",
+            },
+            "gateway-endpoint": {
+                "description": "A list of gateway vpc endpoints",
+                "enum": ["dynamodb", "s3"],
+                "example": "s3",
+                "type": "string",
+            },
+            "interface-endpoint": {
+                "description": "A list of interface vpc endpoints",
+                "enum": [
+                    "access-analyzer",
+                    "application-autoscaling",
+                    "appmesh-envoy-management",
+                    "appstream.api",
+                    "appstream.streaming",
+                    "athena",
+                    "autoscaling",
+                    "autoscaling-plans",
+                    "awsconnector",
+                    "clouddirectory",
+                    "cloudformation",
+                    "cloudtrail",
+                    "codebuild",
+                    "codecommit",
+                    "codepipeline",
+                    "config",
+                    "datasync",
+                    "ec2",
+                    "ec2messages",
+                    "ecr.api",
+                    "ecr.dkr",
+                    "ecs",
+                    "ecs-agent",
+                    "ecs-telemetry",
+                    "elasticfilesystem",
+                    "elasticfilesystem-fips",
+                    "elasticloadbalancing",
+                    "events",
+                    "execute-api",
+                    "git-codecommit",
+                    "glue",
+                    "kinesis-firehose",
+                    "kinesis-streams",
+                    "kms",
+                    "logs",
+                    "monitoring",
+                    "notebook",
+                    "qldb.session",
+                    "rekognition",
+                    "sagemaker.api",
+                    "sagemaker.runtime",
+                    "secretsmanager",
+                    "servicecatalog",
+                    "sms",
+                    "sns",
+                    "sqs",
+                    "ssm",
+                    "ssmmessages",
+                    "storagegateway",
+                    "sts",
+                    "transfer",
+                    "transfer.server",
+                    "workspaces",
+                ],
+                "example": "ec2",
+                "type": "string",
+            },
+            "networking.CreateCidrExclusion": {
+                "additionalProperties": false,
+                "properties": {
+                    "Cidr": {
+                        "description": "CIDR Range in quad dot notation.",
+                        "example": "10.128.0.0\/19",
+                        "type": "string",
+                    },
+                    "Description": {
+                        "description": "Longer description of what the CIDR Exclusion is used for.",
+                        "example": "This Reservation blocks out existing legacy VPCs",
+                        "maxLength": 2048,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the CIDR Exclusion.",
+                        "example": "legacy-vpcs",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["Name", "Cidr"],
+                "type": "object",
+            },
+            "networking.CreateCidrRange": {
+                "additionalProperties": false,
+                "properties": {
+                    "Cidr": {
+                        "description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/23",
+                        "example": "10.128.0.0\/23",
+                        "type": "string",
+                    },
+                    "Description": {
+                        "description": "Longer description of what the CIDR Range is used for.",
+                        "example": "CIDR Range used for team ABCD application 1234",
+                        "maxLength": 2048,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the CIDR Range.",
+                        "example": "prod",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["Name", "Cidr"],
+                "type": "object",
+            },
+            "networking.CreateDnsResolver": {
+                "additionalProperties": false,
+                "properties": {
+                    "Name": {
+                        "description": "Name of Stax DNS Resolver.",
+                        "example": "dns",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "NumberOfInterfaces": {
+                        "description": "The number of ENIs to attach to the Stax DNS Resolvers.",
+                        "example": 2,
+                        "type": "integer",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["Name", "NumberOfInterfaces"],
+                "type": "object",
+            },
+            "networking.CreateDnsRule": {
+                "additionalProperties": false,
+                "properties": {
+                    "DomainName": {
+                        "description": "Domain name to forward DNS queries for.",
+                        "example": "test.local",
+                        "maxLength": 128,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "ForwarderIpAddresses": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The IP Addresses to forward DNS queries to.",
+                                "example": ["192.168.0.1", "192.168.0.2"],
+                                "items": {"type": "string"},
+                                "type": "array",
+                            },
+                        ]
+                    },
+                    "Name": {
+                        "description": "Name of Stax DNS Rule.",
+                        "example": "on-premises",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["Name", "DomainName"],
+                "type": "object",
+            },
+            "networking.CreateHub": {
+                "additionalProperties": false,
+                "properties": {
+                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "AmazonSideAsn": {
+                        "description": "A private Autonomous System Number (ASN) for the Amazon side of a BGP session",
+                        "example": 64512,
+                        "maximum": 65534,
+                        "minimum": 64512,
+                        "type": "integer",
+                    },
+                    "Cidr": {
+                        "description": "CIDR Range in quad dot notation. This range is a private network range with a size between \/8 to \/22 for the Transit VPC",
+                        "example": "10.128.0.0\/22",
+                        "type": "string",
+                    },
+                    "CidrExclusions": {
+                        "items": {"$ref": "#\/components\/schemas\/CidrExclusion"},
+                        "type": "array",
+                    },
+                    "CidrRangeName": {
+                        "description": "Name of the CIDR Range where the Transit VPC lives.",
+                        "example": "myrange",
+                        "maxLength": 64,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "CreateInternetGateway": {
+                        "description": "Boolean value declaring to create an Internet Gateway",
+                        "example": true,
+                        "type": "boolean",
+                    },
+                    "CreateNatGateway": {
+                        "description": "Boolean value declaring to create NAT Gateways",
+                        "example": true,
+                        "type": "boolean",
+                    },
+                    "Description": {
+                        "description": "Longer description of what the Stax Networking Hub is used for.",
+                        "example": "This Hub is for a team ABCD applications",
+                        "maxLength": 2048,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "GatewayEndpoints": {
+                        "items": {"$ref": "#\/components\/schemas\/gateway-endpoint"},
+                        "type": "array",
+                    },
+                    "InterfaceEndpoints": {
+                        "items": {"$ref": "#\/components\/schemas\/interface-endpoint"},
+                        "type": "array",
+                    },
+                    "Name": {
+                        "description": "Name of Stax Networking Hub.",
+                        "example": "prod",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "PhzSuffix": {
+                        "description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
+                        "example": "my-domain.cloud",
+                        "type": "string",
+                    },
+                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": [
+                    "Name",
+                    "AccountId",
+                    "Region",
+                    "Cidr",
+                    "CreateNatGateway",
+                    "CreateInternetGateway",
+                ],
+                "type": "object",
+            },
+            "networking.CreateVpc": {
+                "additionalProperties": false,
+                "properties": {
+                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "CidrRangeId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "CreateInternetGateway": {
+                        "description": "Boolean value declaring to create an Internet Gateway",
+                        "example": true,
+                        "type": "boolean",
+                    },
+                    "Description": {
+                        "description": "Longer description of what the Stax VPC is used for.",
+                        "example": "VPC for a non-prod microservice",
+                        "maxLength": 2048,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "GatewayEndpoints": {
+                        "items": {"$ref": "#\/components\/schemas\/gateway-endpoint"},
+                        "type": "array",
+                    },
+                    "Name": {
+                        "description": "Name of Stax VPC",
+                        "example": "dev-ms-customers",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "PhzPrefix": {
+                        "description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
+                        "example": "dev",
+                        "type": "string",
+                    },
+                    "Region": {"$ref": "#\/components\/schemas\/AwsRegion"},
+                    "Size": {
+                        "description": "Size of the VPC.",
+                        "enum": ["SMALL", "MEDIUM", "LARGE"],
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "Type": {
+                        "description": "Type of VPC. The Type determines what Route Tables are attached to the VPC",
+                        "enum": ["ISOLATED", "FLAT", "SHAREDSERVICES"],
+                        "type": "string",
+                    },
+                    "Zone": {
+                        "description": "All 'Flat' VPCs in the same Zone can communicate to each other.",
+                        "example": "my-zone",
+                        "maxLength": 64,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                },
+                "required": [
+                    "Name",
+                    "CidrRangeId",
+                    "AccountId",
+                    "Region",
+                    "Size",
+                    "Type",
+                    "CreateInternetGateway",
+                ],
+                "type": "object",
+            },
+            "networking.ReadCidrExclusions": {
+                "additionalProperties": false,
+                "properties": {
+                    "Exclusions": {
+                        "items": {"$ref": "#\/components\/schemas\/CidrExclusion"},
+                        "type": "array",
+                    }
+                },
+                "required": ["Exclusions"],
+                "type": "object",
+            },
+            "networking.ReadCidrRanges": {
+                "additionalProperties": false,
+                "properties": {
+                    "Ranges": {
+                        "items": {"$ref": "#\/components\/schemas\/CidrRange"},
+                        "type": "array",
+                    }
+                },
+                "required": ["Ranges"],
+                "type": "object",
+            },
+            "networking.ReadDnsResolvers": {
+                "additionalProperties": false,
+                "properties": {
+                    "DnsResolvers": {
+                        "items": {"$ref": "#\/components\/schemas\/DNSResolver"},
+                        "type": "array",
+                    }
+                },
+                "required": ["DnsResolvers"],
+                "type": "object",
+            },
+            "networking.ReadDnsRules": {
+                "additionalProperties": false,
+                "properties": {
+                    "DnsRules": {
+                        "items": {"$ref": "#\/components\/schemas\/DNSRule"},
+                        "type": "array",
+                    }
+                },
+                "required": ["DnsRules"],
+                "type": "object",
+            },
+            "networking.ReadHubs": {
+                "additionalProperties": false,
+                "properties": {
+                    "Hubs": {
+                        "items": {"$ref": "#\/components\/schemas\/NetworkingHub"},
+                        "type": "array",
+                    }
+                },
+                "required": ["Hubs"],
+                "type": "object",
+            },
+            "networking.ReadVpcs": {
+                "additionalProperties": false,
+                "properties": {
+                    "Vpcs": {
+                        "items": {"$ref": "#\/components\/schemas\/VPC"},
+                        "type": "array",
+                    }
+                },
+                "required": ["Vpcs"],
+                "type": "object",
+            },
+            "networking.UpdateCidrExclusion": {
+                "additionalProperties": false,
+                "properties": {
+                    "Description": {
+                        "description": "Longer description of what the CIDR Exclusion is used for.",
+                        "maxLength": 2048,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the CIDR Exclusion.",
+                        "example": "data-center",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "type": "object",
+            },
+            "networking.UpdateCidrRange": {
+                "additionalProperties": false,
+                "properties": {
+                    "Description": {
+                        "description": "Longer description of what the CIDR Range is used for.",
+                        "example": "CIDR Range used for team ABCD application 1234",
+                        "maxLength": 2048,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the CIDR Range.",
+                        "example": "prod",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "type": "object",
+            },
+            "networking.UpdateDnsResolver": {
+                "additionalProperties": false,
+                "properties": {
+                    "Name": {
+                        "description": "Name of Stax DNS Resolver.",
+                        "example": "dns",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "NumberOfInterfaces": {
+                        "description": "The number of ENIs to attach to the DNS Resolvers.",
+                        "example": 2,
+                        "type": "integer",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "type": "object",
+            },
+            "networking.UpdateDnsRule": {
+                "additionalProperties": false,
+                "properties": {
+                    "ForwarderIpAddresses": {
+                        "anyOf": [
+                            {"nullable": true},
+                            {
+                                "description": "The IP Addresses to forward DNS queries to.",
+                                "example": ["192.168.0.1", "192.168.0.2"],
+                                "items": {"type": "string"},
+                                "type": "array",
+                            },
+                        ]
+                    },
+                    "Name": {
+                        "description": "Name of Stax DNS Rule.",
+                        "example": "on-premises",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "type": "object",
+            },
+            "networking.UpdateHub": {
+                "additionalProperties": false,
+                "properties": {
+                    "CreateInternetGateway": {
+                        "description": "Boolean value declaring to create an Internet Gateway",
+                        "example": true,
+                        "type": "boolean",
+                    },
+                    "CreateNatGateway": {
+                        "description": "Boolean value declaring to create NAT Gateways",
+                        "example": true,
+                        "type": "boolean",
+                    },
+                    "Description": {
+                        "description": "Longer description of what the Stax Networking Hub is used for.",
+                        "example": "This Hub is for connectivity from headquaters to VPC workloads",
+                        "maxLength": 2048,
+                        "type": "string",
+                    },
+                    "InterfaceEndpoints": {
+                        "items": {"$ref": "#\/components\/schemas\/interface-endpoint"},
+                        "type": "array",
+                    },
+                    "Name": {
+                        "description": "Name of Stax Networking Hub",
+                        "example": "prod",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "PhzSuffix": {
+                        "description": "The suffix used to create Route53 Private Hosted Zones names within the Networking Hub, cannot be modified once set",
+                        "example": "my-domain.cloud",
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "type": "object",
+            },
+            "networking.UpdateVpc": {
+                "additionalProperties": false,
+                "properties": {
+                    "CreateInternetGateway": {
+                        "description": "Boolean value declaring to create an Internet Gateway",
+                        "example": true,
+                        "type": "boolean",
+                    },
+                    "Description": {
+                        "description": "Longer description of what this VPC is used for.",
+                        "maxLength": 2048,
+                        "type": "string",
+                    },
+                    "GatewayEndpoints": {
+                        "items": {"$ref": "#\/components\/schemas\/gateway-endpoint"},
+                        "type": "array",
+                    },
+                    "Name": {
+                        "description": "Name of the Stax VPC",
+                        "example": "prod",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "PhzPrefix": {
+                        "description": "The unique prefix to combine with the PhzSuffix to create a Route53 Private Hosted Zone for the VPC, cannot be modified once set",
+                        "example": "dev",
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "type": "object",
+            },
+            "organisations.AttachPolicy": {
+                "properties": {"PolicyId": {"$ref": "#\/components\/schemas\/uuidv4"}},
+                "required": ["PolicyId"],
+                "type": "object",
+            },
+            "organisations.CreatePolicy": {
+                "properties": {
+                    "Description": {
+                        "description": "Description of the Policy.",
+                        "example": "A service control policy that denies access to all.",
+                        "maxLength": 1024,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Policy.",
+                        "example": "DenyAll",
+                        "maxLength": 128,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "Policy": {"type": "string"},
+                },
+                "required": ["Name", "Description", "Policy"],
+                "type": "object",
+            },
+            "organisations.ReadOrganisations": {
+                "properties": {
+                    "Organisations": {
+                        "items": {"$ref": "#\/components\/schemas\/Organisation"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "organisations.ReadPolicies": {
+                "properties": {
+                    "Policies": {
+                        "items": {"$ref": "#\/components\/schemas\/Policy"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "organisations.UpdatePolicy": {
+                "properties": {
+                    "Description": {
+                        "description": "Description of the Policy.",
+                        "example": "A service control policy that denies access to all.",
+                        "maxLength": 1024,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Policy.",
+                        "example": "DenyAll",
+                        "maxLength": 128,
+                        "minLength": 3,
+                        "type": "string",
+                    },
+                    "Policy": {"type": "string"},
+                },
+                "type": "object",
+            },
+            "ro-uuidv4": {
+                "example": "e893d7e0-9306-11e9-bc42-526af7764f64",
+                "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                "readOnly": true,
+                "type": "string",
+            },
+            "teams.CreateApiToken": {
+                "additionalProperties": false,
+                "properties": {
+                    "Description": {
+                        "description": "Longer description of what this Token is used for.",
+                        "example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
+                        "maxLength": 1024,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of API Token",
+                        "example": "gitlab-cicd",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "pattern": "^([0-9a-zA-Z_.-]+)$",
+                        "type": "string",
+                    },
+                    "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
+                    "StoreToken": {
+                        "default": true,
+                        "description": "Store the Access and Secret key in SSM, in your security account.",
+                        "example": true,
+                        "type": "boolean",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "TokenKeyId": {
+                        "default": "alias\/stax-api-tokens",
+                        "description": "If you choose to store your keys in SSM, encrypt them with this KMS Key",
+                        "example": "alias\/my-custom-key",
+                        "maxLength": 128,
+                        "minLength": 7,
+                        "pattern": "^([a-zA-Z0-9:\/_-]+)$",
+                        "type": "string",
+                    },
+                },
+                "required": ["Name", "Role"],
+                "type": "object",
+            },
+            "teams.CreateApiTokenResponse": {
+                "properties": {
+                    "ApiTokens": {
+                        "items": {
+                            "properties": {
+                                "AccessKey": {
+                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                },
+                                "CreatedBy": {
+                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                },
+                                "CreatedTS": {
+                                    "description": "Created timestamp.",
+                                    "example": "2018-10-11T01:05:45.000Z",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "type": "string",
+                                },
+                                "Description": {
+                                    "description": "Longer description of what this Token is used for.",
+                                    "example": "This token is for deployment pipelines in Gitlab to deploy to dev environments",
+                                    "maxLength": 1024,
+                                    "type": "string",
+                                },
+                                "Name": {
+                                    "description": "Name of API Token",
+                                    "example": "gitlab-cicd",
+                                    "maxLength": 64,
+                                    "minLength": 2,
+                                    "pattern": "^([0-9a-zA-Z_.-]+)$",
+                                    "type": "string",
+                                },
+                                "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
+                                "SecretKey": {
+                                    "maxLength": 32,
+                                    "minLength": 32,
+                                    "type": "string",
+                                },
+                                "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                            },
+                            "required": ["AccessKey", "SecretKey"],
+                            "type": "object",
+                        },
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "teams.CreateGroup": {
+                "properties": {
+                    "Name": {
+                        "description": "Name of User Group",
+                        "example": "devops",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["Name"],
+                "type": "object",
+            },
+            "teams.CreateGroupResponse": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "GroupId": {"$ref": "#\/components\/schemas\/ro-uuidv4"}
+                        },
+                        "type": "object",
+                    },
+                    {"$ref": "#\/components\/schemas\/BaseEvent"},
+                    {
+                        "properties": {
+                            "Detail": {
+                                "$ref": "#\/components\/schemas\/TraceEventDetail"
+                            }
+                        }
+                    },
+                ]
+            },
+            "teams.CreateUser": {
+                "properties": {
+                    "Email": {
+                        "description": "Email address of User.",
+                        "example": "stax.user@example.com",
+                        "format": "email",
+                        "maxLength": 128,
+                        "minLength": 6,
+                        "type": "string",
+                    },
+                    "FirstName": {
+                        "description": "Given Name of the User.",
+                        "example": "John",
+                        "maxLength": 128,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "LastName": {
+                        "description": "Family Name of the User.",
+                        "example": "Doe",
+                        "maxLength": 128,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "PhoneNumber": {
+                        "description": "Phone number of User in E.164 format.",
+                        "example": "+61491570006",
+                        "pattern": "^\\+[1-9]\\d{4,14}$",
+                        "type": "string",
+                    },
+                    "Role": {"$ref": "#\/components\/schemas\/Role"},
+                },
+                "required": ["Email", "FirstName", "LastName"],
+                "type": "object",
+            },
+            "teams.CreateUserResponse": {
+                "allOf": [
+                    {
+                        "properties": {
+                            "CustomerId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TaskId": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                            "TraceId": {"type": "string"},
+                        },
+                        "type": "object",
+                    },
+                    {"$ref": "#\/components\/schemas\/BaseEvent"},
+                    {
+                        "properties": {
+                            "Detail": {
+                                "$ref": "#\/components\/schemas\/TraceEventDetail"
+                            }
+                        }
+                    },
+                ]
+            },
+            "teams.InviteRootUser": {
+                "properties": {
+                    "Email": {
+                        "description": "Email address of User.",
+                        "example": "stax.user@example.com",
+                        "format": "email",
+                        "maxLength": 128,
+                        "minLength": 6,
+                        "type": "string",
+                    }
+                },
+                "required": ["Email"],
+                "type": "object",
+            },
+            "teams.ReadApiTokens": {
+                "properties": {
+                    "ApiTokens": {
+                        "items": {
+                            "properties": {
+                                "AccessKey": {
+                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                },
+                                "CreatedBy": {
+                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                },
+                                "CreatedTS": {
+                                    "description": "Created timestamp.",
+                                    "example": "2018-10-11T01:05:45.000Z",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "type": "string",
+                                },
+                                "Description": {
+                                    "description": "Longer description of what this Token is used for.",
+                                    "example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
+                                    "maxLength": 1024,
+                                    "minLength": 0,
+                                    "type": "string",
+                                },
+                                "ModifiedTS": {
+                                    "description": "Modified timestamp.",
+                                    "example": "2018-10-11T01:05:45.000Z",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "type": "string",
+                                },
+                                "Name": {
+                                    "description": "Name of API Token",
+                                    "example": "gitlab-cicd",
+                                    "maxLength": 64,
+                                    "minLength": 2,
+                                    "pattern": "^([0-9a-zA-Z_.-]+)$",
+                                    "type": "string",
+                                },
+                                "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
+                                "Status": {
+                                    "description": "Status of the Token.",
+                                    "enum": ["ACTIVE", "DELETED"],
+                                    "example": "ACTIVE",
+                                    "type": "string",
+                                },
+                                "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                            },
+                            "type": "object",
+                        },
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "teams.ReadGroups": {
+                "properties": {
+                    "Groups": {
+                        "items": {"$ref": "#\/components\/schemas\/Group"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "teams.ReadUsers": {
+                "properties": {
+                    "Users": {
+                        "items": {"$ref": "#\/components\/schemas\/User"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "teams.UpdateApiToken": {
+                "properties": {
+                    "Description": {
+                        "description": "Longer description of what this Token is used for.",
+                        "example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
+                        "maxLength": 1024,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "type": "object",
+            },
+            "teams.UpdateApiTokenResponse": {
+                "properties": {
+                    "ApiTokens": {
+                        "items": {
+                            "properties": {
+                                "AccessKey": {
+                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                },
+                                "CreatedBy": {
+                                    "$ref": "#\/components\/schemas\/ro-uuidv4"
+                                },
+                                "CreatedTS": {
+                                    "description": "Created timestamp.",
+                                    "example": "2018-10-11T01:05:45.000Z",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "type": "string",
+                                },
+                                "Description": {
+                                    "description": "Longer description of what this Token is used for.",
+                                    "example": "This token is for deployment pipelines in Gitlab to deploy to dev\/test environments",
+                                    "maxLength": 1024,
+                                    "minLength": 0,
+                                    "type": "string",
+                                },
+                                "ModifiedTS": {
+                                    "description": "Modified timestamp.",
+                                    "example": "2018-10-11T01:05:45.000Z",
+                                    "format": "date-time",
+                                    "readOnly": true,
+                                    "type": "string",
+                                },
+                                "Name": {
+                                    "description": "Name of API Token",
+                                    "example": "gitlab-cicd",
+                                    "maxLength": 64,
+                                    "minLength": 2,
+                                    "pattern": "^([0-9a-zA-Z_.-]+)$",
+                                    "type": "string",
+                                },
+                                "Role": {"$ref": "#\/components\/schemas\/ApiRole"},
+                                "Status": {
+                                    "description": "Status of the Token.",
+                                    "enum": ["ACTIVE", "DELETED"],
+                                    "example": "ACTIVE",
+                                    "type": "string",
+                                },
+                                "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                            },
+                            "type": "object",
+                        },
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "teams.UpdateGroup": {
+                "properties": {
+                    "Name": {
+                        "description": "Name of User Group",
+                        "example": "devops",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                },
+                "required": ["Name"],
+                "type": "object",
+            },
+            "teams.UpdateGroupMembers": {
+                "properties": {
+                    "AddMembers": {
+                        "items": {"$ref": "#\/components\/schemas\/UserGroupMemberMap"},
+                        "type": "array",
+                    },
+                    "RemoveMembers": {
+                        "items": {"$ref": "#\/components\/schemas\/UserGroupMemberMap"},
+                        "type": "array",
+                    },
+                },
+                "type": "object",
+            },
+            "teams.UpdateUser": {
+                "properties": {
+                    "Email": {
+                        "description": "Email address of User.",
+                        "example": "stax.user@example.com",
+                        "format": "email",
+                        "maxLength": 128,
+                        "minLength": 6,
+                        "type": "string",
+                    },
+                    "FirstName": {
+                        "description": "Given Name of the User.",
+                        "example": "John",
+                        "maxLength": 128,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "LastName": {
+                        "description": "Family Name of the User.",
+                        "example": "Doe",
+                        "maxLength": 128,
+                        "minLength": 0,
+                        "type": "string",
+                    },
+                    "PhoneNumber": {
+                        "description": "Phone number of User in E.164 format.",
+                        "example": "+61491570006",
+                        "pattern": "^\\+[1-9]\\d{4,14}$",
+                        "type": "string",
+                    },
+                    "Role": {"$ref": "#\/components\/schemas\/Role"},
+                    "Status": {
+                        "description": "Status of User.",
+                        "enum": ["ACTIVE", "DISABLED"],
+                        "type": "string",
+                    },
+                },
+                "type": "object",
+            },
+            "teams.UpdateUserEvent": {
+                "allOf": [
+                    {"$ref": "#\/components\/schemas\/BaseEvent"},
+                    {
+                        "properties": {
+                            "Detail": {
+                                "$ref": "#\/components\/schemas\/TraceEventDetail"
+                            }
+                        }
+                    },
+                ],
+                "type": "object",
+            },
+            "teams.UpdateUserInvite": {"type": "object"},
+            "teams.UpdateUserPassword": {"type": "object"},
+            "users.ReadIdamUsers": {
+                "properties": {
+                    "Users": {
+                        "items": {"$ref": "#\/components\/schemas\/IdamUser"},
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "uuidv4": {
+                "example": "ec5eaa8f-da06-4935-b5ce-05bd957c8bdc",
+                "pattern": "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}",
+                "type": "string",
+            },
+            "workloads.Catalogue": {
+                "properties": {
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "WorkloadCatalogueItems": {
+                        "items": {"$ref": "#\/components\/schemas\/WorkloadCatalogue"},
+                        "type": "array",
+                    },
+                },
+                "required": ["OrganisationId", "WorkloadCatalogueItems"],
+                "type": "object",
+            },
+            "workloads.CreateCatalogueItem": {
+                "properties": {
+                    "Description": {
+                        "description": "Description of the Workload.",
+                        "example": "A Workload to build a VPC in my org",
+                        "maxLength": 1024,
+                        "type": "string",
+                    },
+                    "ManifestBody": {
+                        "description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
+                        "example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
+                        "type": "string",
+                    },
+                    "ManifestURL": {
+                        "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+                        "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+                        "type": "string",
+                    },
+                    "Name": {
+                        "description": "Name of the Workload Catalogue Item to create.",
+                        "example": "my-directory-service",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "Version": {
+                        "description": "Version of the Workload Catalogue Item to create.",
+                        "example": "1.0.2",
+                        "maxLength": 128,
+                        "type": "string",
+                    },
+                },
+                "required": ["Name", "Version"],
+                "type": "object",
+            },
+            "workloads.CreateCatalogueVersion": {
+                "properties": {
+                    "Description": {
+                        "description": "Description of the Workload.",
+                        "example": "A Workload to build a VPC in my org",
+                        "maxLength": 1024,
+                        "type": "string",
+                    },
+                    "ManifestBody": {
+                        "description": "Raw text of a Manifest. Either this or ManifestURL must be provided.",
+                        "example": "Resources:\n    - VPC:\n        Type: AWS::Cloudformation\n        TemplateURL: s3:\/\/{JumaArtifactBucket}\/workload-vpc\/vpc-2-tier-no-NAT.yml\n",
+                        "type": "string",
+                    },
+                    "ManifestURL": {
+                        "description": "HTTPS\/S3 URL of the manifest. Either this or ManifestBody must be provided.",
+                        "example": "S3:\/\/{StaxArtifactBucket}\/workload-vpc\/your-template-ref.yml",
+                        "type": "string",
+                    },
+                    "Parameters": {"$ref": "#\/components\/schemas\/Parameter"},
+                    "Tags": {"$ref": "#\/components\/schemas\/Tags"},
+                    "Version": {
+                        "description": "Version of the Workload Catalogue Item to create.",
+                        "example": "1.0.2",
+                        "maxLength": 128,
+                        "type": "string",
+                    },
+                },
+                "required": ["Version"],
+            },
+            "workloads.CreateWorkload": {
+                "properties": {
+                    "AccountId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "CatalogueId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "CatalogueVersionId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "Id": {"$ref": "#\/components\/schemas\/ro-uuidv4"},
+                    "Name": {
+                        "description": "The Workload name.",
+                        "example": "my-workload-is-cool",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Parameters": {
+                        "items": {"$ref": "#\/components\/schemas\/Parameter"},
+                        "type": "array",
+                    },
+                    "Region": {
+                        "description": "AWS Region the workload will be launched in",
+                        "example": "us-east-1",
+                        "maxLength": 32,
+                        "type": "string",
+                    },
+                    "Tags": {"anyOf": [{"type": "object"}, {"nullable": true}]},
+                },
+                "required": ["Name", "CatalogueId", "AccountId", "Region"],
+                "type": "object",
+            },
+            "workloads.ReadCatalogueItems": {
+                "properties": {
+                    "OrganisationId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "WorkloadCatalogues": {
+                        "items": {
+                            "$ref": "#\/components\/schemas\/workloads.Catalogue"
+                        },
+                        "type": "array",
+                    },
+                },
+                "type": "object",
+            },
+            "workloads.ReadCatalogueManifest": {
+                "properties": {"url": {"type": "string"}},
+                "required": ["url"],
+                "type": "object",
+            },
+            "workloads.ReadCatalogueTemplate": {
+                "properties": {"url": {"type": "string"}},
+                "required": ["url"],
+                "type": "object",
+            },
+            "workloads.ReadCatalogueVersion": {
+                "properties": {
+                    "Versions": {
+                        "items": {
+                            "$ref": "#\/components\/schemas\/WorkloadCatalogueVersion"
+                        },
+                        "type": "array",
+                    }
+                },
+                "type": "object",
+            },
+            "workloads.ReadWorkloads": {
+                "properties": {
+                    "Paging": {"$ref": "#\/components\/schemas\/Pagination"},
+                    "Workloads": {
+                        "items": {"$ref": "#\/components\/schemas\/Workload"},
+                        "type": "array",
+                    },
+                },
+                "required": ["Workloads"],
+                "type": "object",
+            },
+            "workloads.UpdateAll": {
+                "properties": {
+                    "CatalogueId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "CatalogueVersionId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                },
+                "required": ["CatalogueId"],
+                "type": "object",
+            },
+            "workloads.UpdateWorkload": {
+                "properties": {
+                    "CatalogueVersionId": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    "Name": {
+                        "description": "The Workload name.",
+                        "example": "my-workload-is-cool",
+                        "maxLength": 64,
+                        "minLength": 2,
+                        "type": "string",
+                    },
+                    "Tags": {"type": "object"},
+                },
+                "type": "object",
+            },
+        },
+        "securitySchemes": {
+            "sigv4": {
+                "in": "header",
+                "name": "Authorization",
+                "type": "apiKey",
+                "x-amazon-apigateway-authtype": "awsSigv4",
+            }
+        },
+    },
+    "info": {
+        "contact": {"url": "https:\/\/stax.io"},
+        "description": "The Stax API is organised around REST, uses resource-oriented URLs, return responses are JSON and uses standard HTTP response codes, authentication and verbs.",
+        "termsOfService": "\/there_is_no_tos",
+        "title": "Stax Core API",
+        "version": "None",
+    },
+    "openapi": "3.0.0",
+    "paths": {
+        "\/20190206\/account-types\/members": {
+            "put": {
+                "description": "Move Accounts between Account Types.<br\/>",
+                "operationId": "accounts.UpdateAccountTypeMembers",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/accounts.UpdateAccountTypeMembers"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is forbidden.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Account Type members",
+                "tags": ["Accounts"],
+            }
+        },
+        "\/20190206\/account-types\/policies": {
+            "put": {
+                "description": "Add Policies to Account types or Remove Policies from Account Types.<br\/>",
+                "operationId": "accounts.UpdatePolicies",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/accounts.UpdatePolicies"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Account Type Policies",
+                "tags": ["Accounts"],
+            }
+        },
+        "\/20190206\/accounts": {
+            "get": {
+                "description": "Return all AWS Accounts within your Stax Organisation.<br\/>Optionally, return the requested AWS Account.<br\/>",
+                "operationId": "accounts.ReadAccounts",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Account to return.",
+                        "in": "path",
+                        "name": "account_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The Account statuses to return, comma delimited.\n\nFilter options available: INITIALIZING, ACTIVE, SUSPENDED, MAINTENANCE, AWSERROR, CLOSED, OFFBOARDED, DISCOVERED, ERROR.\n",
+                        "in": "query",
+                        "name": "filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Account IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The Account Type IDs to return, comma delimited.\n",
+                        "in": "query",
+                        "name": "account_type_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Pagination - The page number to return.",
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "Pagination - The number of items per page to return.",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "The field to sort on.",
+                        "in": "query",
+                        "name": "sort",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The sort order - up or down?",
+                        "in": "query",
+                        "name": "sort_order",
+                        "required": false,
+                        "schema": {
+                            "default": "DESC",
+                            "enum": ["ASC", "DESC"],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "Do you want all the Tags?",
+                        "in": "query",
+                        "name": "include_tags",
+                        "required": false,
+                        "schema": {"default": true, "type": "boolean"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.ReadAccounts"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Accounts",
+                "tags": ["Accounts"],
+            },
+            "post": {
+                "description": "Create a new Stax-hardened AWS Account in your Stax Organisation.<br\/>",
+                "operationId": "accounts.CreateAccount",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/accounts.CreateAccount"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create Account",
+                "tags": ["Accounts"],
+            },
+        },
+        "\/20190206\/accounts\/discover": {
+            "post": {
+                "description": "Discover all AWS Accounts associated with the org into stax<br\/>Optionally attempt to rediscover an Aws Account that failed discovery<br\/>",
+                "operationId": "accounts.DiscoverAccounts",
+                "parameters": [
+                    {
+                        "description": "The AWS Account Id of the Account to discover.",
+                        "in": "path",
+                        "name": "aws_account_id",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.DiscoverAccountsResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful due to user input.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the account given has already been discovered.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the requested account cannot be discovered.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Discover Accounts",
+                "tags": ["Accounts"],
+            }
+        },
+        "\/20190206\/accounts\/discover\/{aws_account_id}": {
+            "post": {
+                "description": "Discover all AWS Accounts associated with the org into stax<br\/>Optionally attempt to rediscover an Aws Account that failed discovery<br\/>",
+                "operationId": "accounts.DiscoverAccounts",
+                "parameters": [
+                    {
+                        "description": "The AWS Account Id of the Account to discover.",
+                        "in": "path",
+                        "name": "aws_account_id",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.DiscoverAccountsResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful due to user input.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the account given has already been discovered.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the requested account cannot be discovered.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Discover Accounts",
+                "tags": ["Accounts"],
+            }
+        },
+        "\/20190206\/accounts\/onboard": {
+            "post": {
+                "description": "Onboard an existing AWS Account to your Stax Organisation.<br\/>",
+                "operationId": "accounts.OnboardAccount",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/accounts.OnboardAccount"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Onboard AWS Account",
+                "tags": ["Accounts"],
+            }
+        },
+        "\/20190206\/accounts\/types": {
+            "get": {
+                "description": "Return all the Account Types in your Stax Organisation.<br\/>Optionally, return the requested Account Type.<br\/>",
+                "operationId": "accounts.ReadAccountTypes",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Account Type.",
+                        "in": "path",
+                        "name": "account_type_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of AccountType IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Account Types",
+                "tags": ["Accounts"],
+            },
+            "post": {
+                "description": "Create a new Account Type within your Stax Organisation.<br\/>Account Types can be used to set Policies on Accounts and control Group access.<br\/>",
+                "operationId": "accounts.CreateAccountType",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/accounts.CreateAccountType"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.CreateAccountTypeResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is forbidden.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create Account Type",
+                "tags": ["Accounts"],
+            },
+        },
+        "\/20190206\/accounts\/types\/access": {
+            "put": {
+                "description": "Adjust the AWS role permissions between Account Types and Groups.<br\/>",
+                "operationId": "accounts.UpdateAccountTypeAccess",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/accounts.UpdateAccountTypeAccess"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update AWS access",
+                "tags": ["Accounts"],
+            }
+        },
+        "\/20190206\/accounts\/types\/{account_type_id}": {
+            "delete": {
+                "description": "Delete an Account Type from your Stax Organisation.<br\/>An Account Type can only be deleted if there are no attached Accounts.<br\/>",
+                "operationId": "accounts.DeleteAccountType",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Catalogue item.",
+                        "in": "path",
+                        "name": "account_type_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is forbidden.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete Account Type",
+                "tags": ["Accounts"],
+            },
+            "get": {
+                "description": "Return all the Account Types in your Stax Organisation.<br\/>Optionally, return the requested Account Type.<br\/>",
+                "operationId": "accounts.ReadAccountTypes",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Account Type.",
+                        "in": "path",
+                        "name": "account_type_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of AccountType IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Account Types",
+                "tags": ["Accounts"],
+            },
+            "put": {
+                "description": "Change the details of an Account Type, such as the name.<br\/>",
+                "operationId": "accounts.UpdateAccountType",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Account Type to update.",
+                        "in": "path",
+                        "name": "account_type_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/accounts.UpdateAccountType"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.ReadAccountTypes"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is forbidden.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Account Type",
+                "tags": ["Accounts"],
+            },
+        },
+        "\/20190206\/accounts\/{account_id}": {
+            "get": {
+                "description": "Return all AWS Accounts within your Stax Organisation.<br\/>Optionally, return the requested AWS Account.<br\/>",
+                "operationId": "accounts.ReadAccounts",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Account to return.",
+                        "in": "path",
+                        "name": "account_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The Account statuses to return, comma delimited.\n\nFilter options available: INITIALIZING, ACTIVE, SUSPENDED, MAINTENANCE, AWSERROR, CLOSED, OFFBOARDED, DISCOVERED, ERROR.\n",
+                        "in": "query",
+                        "name": "filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Account IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The Account Type IDs to return, comma delimited.\n",
+                        "in": "query",
+                        "name": "account_type_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Pagination - The page number to return.",
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "Pagination - The number of items per page to return.",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "The field to sort on.",
+                        "in": "query",
+                        "name": "sort",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The sort order - up or down?",
+                        "in": "query",
+                        "name": "sort_order",
+                        "required": false,
+                        "schema": {
+                            "default": "DESC",
+                            "enum": ["ASC", "DESC"],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "Do you want all the Tags?",
+                        "in": "query",
+                        "name": "include_tags",
+                        "required": false,
+                        "schema": {"default": true, "type": "boolean"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.ReadAccounts"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Accounts",
+                "tags": ["Accounts"],
+            },
+            "put": {
+                "description": "Change the details of an Account, such as the name, tags or Account Type<br\/>",
+                "operationId": "accounts.UpdateAccount",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Account to update.",
+                        "in": "path",
+                        "name": "account_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/accounts.UpdateAccount"
+                            }
+                        }
+                    },
+                    "required": false,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/accounts.UpdateAccountResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is forbidden.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Account",
+                "tags": ["Accounts"],
+            },
+        },
+        "\/20190206\/api-tokens": {
+            "get": {
+                "description": "Return a list of all API Tokens within your Stax Organisation.<br\/>",
+                "operationId": "teams.ReadApiTokens",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Token to return.",
+                        "in": "path",
+                        "name": "AccessKey",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Access Keys you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: ACTIVE, DELETED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {"default": "ACTIVE", "type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.ReadApiTokens"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch API Tokens",
+                "tags": ["Team", "Beta"],
+            },
+            "post": {
+                "description": "Create an API Token for API\/SDK access within your Stax Organisation.<br\/>",
+                "operationId": "teams.CreateApiToken",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/teams.CreateApiToken"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.CreateApiTokenResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create API Token",
+                "tags": ["Team", "Beta"],
+            },
+        },
+        "\/20190206\/api-tokens\/{AccessKey}": {
+            "delete": {
+                "description": "Delete an API Token from your Stax Organisation.<br\/>",
+                "operationId": "teams.DeleteApiToken",
+                "parameters": [
+                    {
+                        "description": "The UUID of the User to delete.",
+                        "in": "path",
+                        "name": "AccessKey",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.UpdateApiTokenResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete API Token",
+                "tags": ["Team", "Beta"],
+            },
+            "get": {
+                "description": "Return a list of all API Tokens within your Stax Organisation.<br\/>",
+                "operationId": "teams.ReadApiTokens",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Token to return.",
+                        "in": "path",
+                        "name": "AccessKey",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Access Keys you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: ACTIVE, DELETED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {"default": "ACTIVE", "type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.ReadApiTokens"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch API Tokens",
+                "tags": ["Team", "Beta"],
+            },
+            "put": {
+                "description": "Update a Token for API\/SDK access within your Stax Organisation.<br\/>",
+                "operationId": "teams.UpdateApiToken",
+                "parameters": [
+                    {
+                        "description": "The UUID of the API Token to update.",
+                        "in": "path",
+                        "name": "AccessKey",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/teams.UpdateApiToken"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.UpdateApiTokenResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update API Token",
+                "tags": ["Team", "Beta"],
+            },
+        },
+        "\/20190206\/groups": {
+            "get": {
+                "description": "Return all Groups within your Stax Organisation.<br\/>Optionally, return the requested Group.<br\/>",
+                "operationId": "teams.ReadGroups",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Group to return.",
+                        "in": "path",
+                        "name": "group_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Group IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.ReadGroups"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Groups",
+                "tags": ["Groups"],
+            },
+            "post": {
+                "description": "Create a new Group within your Stax Organisation.<br\/>",
+                "operationId": "teams.CreateGroup",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/teams.CreateGroup"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.CreateGroupResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create Group",
+                "tags": ["Groups"],
+            },
+        },
+        "\/20190206\/groups\/members": {
+            "put": {
+                "description": "Add members to a Group or Remove members from a Group<br\/>",
+                "operationId": "teams.UpdateGroupMembers",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/teams.UpdateGroupMembers"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "Could not locate user or group.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Group Members",
+                "tags": ["Groups"],
+            }
+        },
+        "\/20190206\/groups\/{group_id}": {
+            "delete": {
+                "description": "Delete a Group from your Stax Organisation.<br\/>A Group can only be deleted if there are no team members in the Group.<br\/>",
+                "operationId": "teams.DeleteGroup",
+                "parameters": [
+                    {
+                        "description": "The UUID of Group to delete.",
+                        "in": "path",
+                        "name": "group_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The Group still contains members.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The Group could not be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete Group",
+                "tags": ["Groups"],
+            },
+            "get": {
+                "description": "Return all Groups within your Stax Organisation.<br\/>Optionally, return the requested Group.<br\/>",
+                "operationId": "teams.ReadGroups",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Group to return.",
+                        "in": "path",
+                        "name": "group_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Group IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.ReadGroups"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Groups",
+                "tags": ["Groups"],
+            },
+            "put": {
+                "description": "Change the details of a Group, such as the name.<br\/>",
+                "operationId": "teams.UpdateGroup",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Group to update.",
+                        "in": "path",
+                        "name": "group_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/teams.UpdateGroup"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Group",
+                "tags": ["Groups"],
+            },
+        },
+        "\/20190206\/idam\/user": {
+            "get": {
+                "deprecated": true,
+                "description": "(DEPRECATED) Return a list of all IDAM Users in your Stax Organisation.<br\/>",
+                "operationId": "teams.ReadIdamUsers",
+                "parameters": [
+                    {
+                        "description": "The Organisation ID in which the IDAM is deployed to.  If no org_id is supplied, the Customer's default Organisation will be used.",
+                        "in": "path",
+                        "name": "org_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Do you want all the Tags?",
+                        "in": "query",
+                        "name": "include_tags",
+                        "required": false,
+                        "schema": {"default": true, "type": "boolean"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/users.ReadIdamUsers"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch IDAM Users",
+                "tags": ["IDAM", "Deprecated"],
+            },
+            "post": {
+                "description": "Create a new Stax user within your Stax Organisation.<br\/>Stax Users have permission to access the AWS Console\/CLI for AWS Accounts that exist within a Stax Organisation.<br\/>",
+                "operationId": "teams.CreateUser",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/teams.CreateUser"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.CreateUserResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create Stax User",
+                "tags": ["Team"],
+            },
+        },
+        "\/20190206\/idam\/user\/resend-invite\/{user_id}": {
+            "put": {
+                "description": "Re-send the verification email for a Stax User.<br\/>",
+                "operationId": "teams.UpdateUserInvite",
+                "parameters": [
+                    {
+                        "description": "The UUID of the IDAM User to re-invite.",
+                        "in": "path",
+                        "name": "user_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.UpdateUserEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the user has already verified their email address.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the user does not exist in IDAM.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Re-invite Stax user",
+                "tags": ["Team"],
+            }
+        },
+        "\/20190206\/idam\/user\/reset-password\/{user_id}": {
+            "put": {
+                "description": "Send a Stax User a password reset email.<br\/>",
+                "operationId": "teams.UpdateUserPassword",
+                "parameters": [
+                    {
+                        "description": "The UUID of the IDAM User to have password reset.",
+                        "in": "path",
+                        "name": "user_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.UpdateUserEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the user has been deleted.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Reset Stax User's password",
+                "tags": ["Team"],
+            }
+        },
+        "\/20190206\/idam\/user\/{org_id}": {
+            "get": {
+                "deprecated": true,
+                "description": "(DEPRECATED) Return a list of all IDAM Users in your Stax Organisation.<br\/>",
+                "operationId": "teams.ReadIdamUsers",
+                "parameters": [
+                    {
+                        "description": "The Organisation ID in which the IDAM is deployed to.  If no org_id is supplied, the Customer's default Organisation will be used.",
+                        "in": "path",
+                        "name": "org_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Do you want all the Tags?",
+                        "in": "query",
+                        "name": "include_tags",
+                        "required": false,
+                        "schema": {"default": true, "type": "boolean"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/users.ReadIdamUsers"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch IDAM Users",
+                "tags": ["IDAM", "Deprecated"],
+            }
+        },
+        "\/20190206\/idam\/user\/{user_id}": {
+            "put": {
+                "description": "Update a Stax User's details, such as the name, role or email.<br\/>",
+                "operationId": "teams.UpdateUser",
+                "parameters": [
+                    {
+                        "description": "The UUID of the IDAM User to update.",
+                        "in": "path",
+                        "name": "user_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/teams.UpdateUser"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.CreateUserResponse"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Stax User",
+                "tags": ["Team"],
+            }
+        },
+        "\/20190206\/networking\/dnsresolvers\/{dns_resolver_id}": {
+            "delete": {
+                "description": "<br\/>Deletes a Stax DNS Resolver within a Stax Networking Hub.<br\/>",
+                "operationId": "networking.DeleteDnsResolver",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax DNS Resolver to delete.",
+                        "in": "path",
+                        "name": "dns_resolver_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax DNS Resolver to delete cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete DNS Resolver",
+                "tags": ["Beta"],
+            },
+            "get": {
+                "description": "<br\/>Returns the DNS Resolver of the Stax Networking Hub.<br\/>Providing the UUID of a Stax DNS Resolver will return a specific Stax DNS Resolver's details.<br\/>",
+                "operationId": "networking.ReadDnsResolvers",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax Networking Hub where the Stax DNS Resolver is deployed.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Stax DNS Resolver to fetch.",
+                        "in": "path",
+                        "name": "dns_resolver_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Stax DNS Resolver statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+                            "type": "string",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadDnsResolvers"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch DNS Resolvers",
+                "tags": ["Beta"],
+            },
+            "put": {
+                "description": "<br\/>Updates the attributes for a given Stax DNS Resolver. Only supplied values are updated.<br\/>",
+                "operationId": "networking.UpdateDnsResolver",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax DNS Resolver to update.",
+                        "in": "path",
+                        "name": "dns_resolver_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.UpdateDnsResolver"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax DNS Resolver to update cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update DNS Resolver",
+                "tags": ["Beta"],
+            },
+        },
+        "\/20190206\/networking\/dnsresolvers\/{dns_resolver_id}\/dnsrules": {
+            "get": {
+                "description": "<br\/>Returns the Stax DNS Rules of the Stax DNS Resolver.<br\/>Providing the UUID of a Stax DNS Rule will return a specific Stax DNS Rule's details.<br\/>",
+                "operationId": "networking.ReadDnsRules",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax DNS Resolver.",
+                        "in": "path",
+                        "name": "dns_resolver_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Stax DNS Rule to fetch.",
+                        "in": "path",
+                        "name": "dns_rule_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Stax DNS Rule statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+                            "type": "string",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadDnsRules"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch DNS Rules",
+                "tags": ["Beta"],
+            },
+            "post": {
+                "description": "<br\/>Creates a Stax DNS Rule within a Stax DNS Resolver.<br\/>",
+                "operationId": "networking.CreateDnsRule",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax DNS Resolver to create the Stax DNS Rule within.",
+                        "in": "path",
+                        "name": "dns_resolver_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.CreateDnsRule"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax DNS Resolver to create the Stax DNS Rule within cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create DNS Rule",
+                "tags": ["Beta"],
+            },
+        },
+        "\/20190206\/networking\/dnsrules\/{dns_rule_id}": {
+            "delete": {
+                "description": "<br\/>Deletes a Stax DNS Rule within a Stax DNS Resolver<br\/>",
+                "operationId": "networking.DeleteDnsRule",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax DNS Rule.",
+                        "in": "path",
+                        "name": "dns_rule_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax DNS Rule to delete cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete DNS Rule",
+                "tags": ["Beta"],
+            },
+            "get": {
+                "description": "<br\/>Returns the Stax DNS Rules of the Stax DNS Resolver.<br\/>Providing the UUID of a Stax DNS Rule will return a specific Stax DNS Rule's details.<br\/>",
+                "operationId": "networking.ReadDnsRules",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax DNS Resolver.",
+                        "in": "path",
+                        "name": "dns_resolver_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Stax DNS Rule to fetch.",
+                        "in": "path",
+                        "name": "dns_rule_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Stax DNS Rule statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+                            "type": "string",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadDnsRules"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch DNS Rules",
+                "tags": ["Beta"],
+            },
+            "put": {
+                "description": "<br\/>Updates the attributes for a given Stax DNS Rule. Only supplied values are updated.<br\/>",
+                "operationId": "networking.UpdateDnsRule",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax DNS Rule to update.",
+                        "in": "path",
+                        "name": "dns_rule_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.UpdateDnsRule"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax Networking Hub doesn't match supplied credentials.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax DNS Rule to update cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update DNS Rule",
+                "tags": ["Beta"],
+            },
+        },
+        "\/20190206\/networking\/exclusions": {
+            "get": {
+                "description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
+                "operationId": "networking.ReadCidrExclusions",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub to list Exclusions in.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Exclusion to read.",
+                        "in": "path",
+                        "name": "exclusion_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {"default": "ACTIVE", "type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch CIDR Exclusions",
+                "tags": ["Networking"],
+            }
+        },
+        "\/20190206\/networking\/exclusions\/{exclusion_id}": {
+            "delete": {
+                "description": "<br\/>Deletes a CIDR Exclusion within a Stax Networking Hub.<br\/>",
+                "operationId": "networking.DeleteCidrExclusion",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub to delete the CIDR Exclusion.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Exclusion to Delete.",
+                        "in": "path",
+                        "name": "exclusion_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The CIDR Exclusion to delete cannot be found or is already deleted.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete CIDR Exclusion",
+                "tags": ["Networking"],
+            },
+            "get": {
+                "description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
+                "operationId": "networking.ReadCidrExclusions",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub to list Exclusions in.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Exclusion to read.",
+                        "in": "path",
+                        "name": "exclusion_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {"default": "ACTIVE", "type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch CIDR Exclusions",
+                "tags": ["Networking"],
+            },
+            "put": {
+                "description": "<br\/>Updates a CIDR Exclusion within a Stax Networking Hub<br\/>",
+                "operationId": "networking.UpdateCidrExclusion",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub to update the CIDR Exclusion.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Exclusion to update.",
+                        "in": "path",
+                        "name": "exclusion_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.UpdateCidrExclusion"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.UpdateCidrExclusion"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The CIDR Exclusion to update cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update CIDR Exclusion",
+                "tags": ["Networking"],
+            },
+        },
+        "\/20190206\/networking\/hubs": {
+            "get": {
+                "description": "<br\/>Returns a list of networking hubs in your Stax Organisation.<br\/>Can use the UUID of a Hub to return a specific hub details.<br\/>",
+                "operationId": "networking.ReadHubs",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, UPDATE_IN_PROGRESS, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+                            "type": "string",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadHubs"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Networking Hubs",
+                "tags": ["Networking"],
+            },
+            "post": {
+                "description": "<br\/>Creates Stax Networking Hub within your Stax Organisation.<br\/>",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.CreateHub"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The account to deploy a hub does not exist.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create Networking Hub",
+                "tags": ["Networking"],
+            },
+        },
+        "\/20190206\/networking\/hubs\/{hub_id}": {
+            "delete": {
+                "description": "<br\/>Deletes a hub from the Stax Organisation<br\/>",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub to delete.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The hub to be deleted doesn't exist or is already deleted.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete Networking Hub",
+                "tags": ["Networking"],
+            },
+            "get": {
+                "description": "<br\/>Returns a list of networking hubs in your Stax Organisation.<br\/>Can use the UUID of a Hub to return a specific hub details.<br\/>",
+                "operationId": "networking.ReadHubs",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, UPDATE_IN_PROGRESS, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+                            "type": "string",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadHubs"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Networking Hubs",
+                "tags": ["Networking"],
+            },
+            "put": {
+                "description": "<br\/>Updates a various attributes for a given hub. Only supplied values are updated.<br\/>",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub to update.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.UpdateHub"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "An active hub to be updated does not exist",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Networking Hub",
+                "tags": ["Networking"],
+            },
+        },
+        "\/20190206\/networking\/hubs\/{hub_id}\/dnsresolvers": {
+            "get": {
+                "description": "<br\/>Returns the DNS Resolver of the Stax Networking Hub.<br\/>Providing the UUID of a Stax DNS Resolver will return a specific Stax DNS Resolver's details.<br\/>",
+                "operationId": "networking.ReadDnsResolvers",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax Networking Hub where the Stax DNS Resolver is deployed.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Stax DNS Resolver to fetch.",
+                        "in": "path",
+                        "name": "dns_resolver_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Stax DNS Resolver statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+                            "type": "string",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadDnsResolvers"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch DNS Resolvers",
+                "tags": ["Beta"],
+            },
+            "post": {
+                "description": "<br\/>Creates a Stax DNS Resolver within a Stax Networking Hub.<br\/>",
+                "operationId": "networking.CreateDnsResolver",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Stax Networking Hub to deploy the Stax DNS Resolver.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.CreateDnsResolver"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Stax Networking Hub to deploy the Stax DNS Resolver cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create DNS Resolver",
+                "tags": ["Beta"],
+            },
+        },
+        "\/20190206\/networking\/hubs\/{hub_id}\/exclusions": {
+            "get": {
+                "description": "<br\/>Returns a list of CIDR Exclusions.<br\/>Can use the UUID of a CIDR Exclusions to return a specific CIDR Exclusions details.<br\/>",
+                "operationId": "networking.ReadCidrExclusions",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub to list Exclusions in.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Exclusion to read.",
+                        "in": "path",
+                        "name": "exclusion_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {"default": "ACTIVE", "type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch CIDR Exclusions",
+                "tags": ["Networking"],
+            },
+            "post": {
+                "description": "<br\/>Creates a CIDR Exclusion within a Stax Networking Hub<br\/>",
+                "operationId": "networking.CreateCidrExclusion",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub where the CIDR Exclusion is created in.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.CreateCidrExclusion"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrExclusions"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The hub to create the CIDR Exclusion is not found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create CIDR Exclusion",
+                "tags": ["Networking"],
+            },
+        },
+        "\/20190206\/networking\/hubs\/{hub_id}\/ranges": {
+            "get": {
+                "description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
+                "operationId": "networking.ReadCidrRanges",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub you want the Ranges for.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Range to read.",
+                        "in": "path",
+                        "name": "range_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {"default": "ACTIVE", "type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch CIDR Ranges",
+                "tags": ["Networking"],
+            },
+            "post": {
+                "description": "<br\/>Creates a CIDR Range within a Stax Networking Hub<br\/>",
+                "operationId": "networking.CreateCidrRange",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub where the CIDR Range is created in.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.CreateCidrRange"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The hub to create the CIDR Range is not found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create CIDR Range",
+                "tags": ["Networking"],
+            },
+        },
+        "\/20190206\/networking\/hubs\/{hub_id}\/vpcs": {
+            "get": {
+                "description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
+                "operationId": "networking.ReadVpcs",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub where the VPC is.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the VPC to read.",
+                        "in": "path",
+                        "name": "vpc_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
+                        "in": "query",
+                        "name": "type",
+                        "required": false,
+                        "schema": {
+                            "default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
+                            "type": "string",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadVpcs"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch VPCs",
+                "tags": ["Networking"],
+            },
+            "post": {
+                "description": "<br\/>Creates a VPC within a Stax Networking Hub<br\/>",
+                "operationId": "networking.CreateVpc",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub where the VPC is.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.CreateVpc"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "No permission to create VPC in the specified AWS Account",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The hub to create the VPC is not found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create VPC",
+                "tags": ["Networking"],
+            },
+        },
+        "\/20190206\/networking\/ranges": {
+            "get": {
+                "description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
+                "operationId": "networking.ReadCidrRanges",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub you want the Ranges for.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Range to read.",
+                        "in": "path",
+                        "name": "range_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {"default": "ACTIVE", "type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch CIDR Ranges",
+                "tags": ["Networking"],
+            }
+        },
+        "\/20190206\/networking\/ranges\/{range_id}": {
+            "delete": {
+                "description": "<br\/>Deletes a CIDR Range within a Stax Networking Hub. No existing VPCs can be in the CIDR Range.<br\/>",
+                "operationId": "networking.DeleteCidrRange",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub to delete the CIDR Range.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Range to delete.",
+                        "in": "path",
+                        "name": "range_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The CIDR Range to delete cannot be found or is already deleted.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete CIDR Range",
+                "tags": ["Networking"],
+            },
+            "get": {
+                "description": "<br\/>Returns a list of CIDR Ranges.<br\/>Can use the UUID of a CIDR Range to return a specific CIDR Range details.<br\/>",
+                "operationId": "networking.ReadCidrRanges",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub you want the Ranges for.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the Range to read.",
+                        "in": "path",
+                        "name": "range_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The Hub statuses to return, comma delimited.\n\nFilter options available: ACTIVE, DELETED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {"default": "ACTIVE", "type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadCidrRanges"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch CIDR Ranges",
+                "tags": ["Networking"],
+            },
+            "put": {
+                "description": "<br\/>Updates a CIDR Range within a Stax Networking Hub<br\/>",
+                "operationId": "networking.UpdateCidrRange",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub to update the CIDR Range.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the CIDR Range to update.",
+                        "in": "path",
+                        "name": "range_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.UpdateCidrRange"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.UpdateCidrRange"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The CIDR Range to update cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update CIDR Range",
+                "tags": ["Networking"],
+            },
+        },
+        "\/20190206\/networking\/vpcs": {
+            "get": {
+                "description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
+                "operationId": "networking.ReadVpcs",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub where the VPC is.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the VPC to read.",
+                        "in": "path",
+                        "name": "vpc_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
+                        "in": "query",
+                        "name": "type",
+                        "required": false,
+                        "schema": {
+                            "default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
+                            "type": "string",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadVpcs"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch VPCs",
+                "tags": ["Networking"],
+            }
+        },
+        "\/20190206\/networking\/vpcs\/{vpc_id}": {
+            "delete": {
+                "description": "<br\/>Deletes a VPC within a Stax Networking Hub<br\/>",
+                "operationId": "networking.DeleteVpc",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub where the VPC is.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the VPC to delete.",
+                        "in": "path",
+                        "name": "vpc_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The VPC to delete cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete VPC",
+                "tags": ["Networking"],
+            },
+            "get": {
+                "description": "<br\/>Returns a list of VPCs.<br\/>Can use the UUID of a VPC to return a specific VPC details.<br\/>",
+                "operationId": "networking.ReadVpcs",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub where the VPC is.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the VPC to read.",
+                        "in": "path",
+                        "name": "vpc_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The VPC statuses to return, comma delimited.\n\nFilter options available: ACTIVE, CREATE_IN_PROGRESS, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED\n",
+                        "in": "query",
+                        "name": "status",
+                        "required": false,
+                        "schema": {
+                            "default": "ACTIVE,CREATE_IN_PROGRESS,CREATE_FAILED",
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "The VPC type to return, comma delimited.\n\nFilter options available: FLAT, ISOLATED, TRANSIT, SHAREDSERVICES\n",
+                        "in": "query",
+                        "name": "type",
+                        "required": false,
+                        "schema": {
+                            "default": "FLAT,ISOLATED,TRANSIT,SHAREDSERVICES",
+                            "type": "string",
+                        },
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/networking.ReadVpcs"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch VPCs",
+                "tags": ["Networking"],
+            },
+            "put": {
+                "description": "<br\/>Updates a VPC within a Stax Networking Hub<br\/>",
+                "operationId": "networking.UpdateVpc",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Hub where the VPC is.",
+                        "in": "path",
+                        "name": "hub_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                    {
+                        "description": "The UUID of the VPC to update.",
+                        "in": "path",
+                        "name": "vpc_id",
+                        "required": true,
+                        "schema": {"$ref": "#\/components\/schemas\/uuidv4"},
+                    },
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/networking.UpdateVpc"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The VPC to update cannot be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update VPC",
+                "tags": ["Networking"],
+            },
+        },
+        "\/20190206\/organisations": {
+            "get": {
+                "description": "Return a list of your Stax Organisations.<br\/>A Stax Organisation is an instance of Stax which houses your AWS Accounts, Workloads and IDAM Users.<br\/>",
+                "operationId": "organisations.ReadOrganisations",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/organisations.ReadOrganisations"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful. The response body contains an Organisation array.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Stax Organisations",
+                "tags": ["Organisations"],
+            }
+        },
+        "\/20190206\/organisations\/current": {
+            "get": {
+                "description": "Return the current users Organisation.<br\/>A Stax Organisation is an instance of Stax which houses your AWS Accounts, Workloads and IDAM Users.<br\/>",
+                "operationId": "organisations.ReadOrganisation",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/organisations.ReadOrganisations"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful. The response body contains an Organisation array.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Stax Organisations",
+                "tags": ["Organisations"],
+            }
+        },
+        "\/20190206\/policies": {
+            "get": {
+                "description": "Return all Policies in your Stax Organisation.<br\/>Optionally, return the requested Policy.<br\/>",
+                "operationId": "organisations.ReadPolicies",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Policy to return.",
+                        "in": "path",
+                        "name": "policy_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/organisations.ReadPolicies"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Policies",
+                "tags": ["Policies"],
+            },
+            "post": {
+                "description": "Create a Policy in your Stax Organisation.<br\/>",
+                "operationId": "organisations.CreatePolicy",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/organisations.CreatePolicy"
+                            }
+                        }
+                    },
+                    "required": false,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/CreatePolicyEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create Policy",
+                "tags": ["Policies"],
+            },
+        },
+        "\/20190206\/policies\/organisation\/{policy_id}": {
+            "delete": {
+                "description": "Detach a Policy from your Stax Organisation.<br\/>The policy will no longer apply to all Account Types within the Organisation.<br\/>",
+                "operationId": "organisations:DetachPolicy",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Policy to detach.",
+                        "in": "path",
+                        "name": "policy_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Detach Policy from Organisation",
+                "tags": ["Policies"],
+            },
+            "put": {
+                "description": "Attach a Policy to your Stax Organisation.<br\/>The policy will apply to all Account Types within the Organisation.<br\/>",
+                "operationId": "organisations:AttachPolicy",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Policy to attach.",
+                        "in": "path",
+                        "name": "policy_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/organisations.AttachPolicy"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "Unable to attach foundation policy to an Organisation.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Attach Policy to Organisation",
+                "tags": ["Policies"],
+            },
+        },
+        "\/20190206\/policies\/{policy_id}": {
+            "delete": {
+                "description": "Delete a Policy from your Stax Organisation.<br\/>",
+                "operationId": "organisations.DeletePolicy",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Policy to delete.",
+                        "in": "path",
+                        "name": "policy_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/DeletePolicyEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete Policy",
+                "tags": ["Policies"],
+            },
+            "get": {
+                "description": "Return all Policies in your Stax Organisation.<br\/>Optionally, return the requested Policy.<br\/>",
+                "operationId": "organisations.ReadPolicies",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Policy to return.",
+                        "in": "path",
+                        "name": "policy_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/organisations.ReadPolicies"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Policies",
+                "tags": ["Policies"],
+            },
+            "put": {
+                "description": "Update an existing Policy within your Stax Organisation.<br\/>",
+                "operationId": "organisations.UpdatePolicy",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Policy to update.",
+                        "in": "path",
+                        "name": "policy_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/organisations.UpdatePolicy"
+                            }
+                        }
+                    },
+                    "required": false,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/UpdatePolicyEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Policy",
+                "tags": ["Policies"],
+            },
+        },
+        "\/20190206\/public\/check-alias\/{alias}": {
+            "get": {
+                "description": "Check if an Alias is available or if it is already in use by another Stax customer.<br\/>The Alias is the unique identifier for a Customer's Stax Organisation.<br\/>",
+                "operationId": "public.CheckAlias",
+                "parameters": [
+                    {
+                        "description": "A unique string containing characters a-z, A-Z, 0-9.\nHyphens can also be used, but not at the start or end of the alias.\n",
+                        "in": "path",
+                        "name": "alias",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Alias"}
+                            }
+                        },
+                        "description": "The response returned if the Alias is available and not in use by another Customer.",
+                    },
+                    "409": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/AliasInUse"}
+                            }
+                        },
+                        "description": "The Alias is already in use by another Customer.",
+                    },
+                },
+                "summary": "Check Alias availability",
+                "tags": ["Public"],
+            }
+        },
+        "\/20190206\/public\/config": {
+            "get": {
+                "description": "This is an unauthenticated endpoint returning your configuration variables which are required to authenticate API requests.<br\/>",
+                "operationId": "public.ReadConfig",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Config"}
+                            }
+                        },
+                        "description": "Configuration values required to authenicate API requests.",
+                    }
+                },
+                "summary": "Fetch public config",
+                "tags": ["Public"],
+            }
+        },
+        "\/20190206\/task\/{task_id}": {
+            "get": {
+                "description": "Return the status of the requested Task.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
+                "operationId": "tasks.ReadTask",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Task to return.",
+                        "in": "path",
+                        "name": "task_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Task"}
+                            }
+                        },
+                        "description": "The response returned for a valid Task.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the requested Task could not be found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch status of Task",
+                "tags": ["Tasks"],
+            }
+        },
+        "\/20190206\/tasks": {
+            "get": {
+                "description": "Return all Tasks for your Stax Organisation.<br\/>Optionally, return all tasks with the specified status for your Stax Organisation.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
+                "operationId": "tasks.ReadTasks",
+                "parameters": [
+                    {
+                        "description": "Return all tasks of this status.\n\nAccepted values are: RUNNING, SUCCEEDED or FAILED.\n",
+                        "in": "path",
+                        "name": "task_status",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/GetTasks"}
+                            }
+                        },
+                        "description": "The Tasks returned for a valid task_status.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The task_status not supplied or invalid.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch all Tasks by status",
+                "tags": ["Tasks"],
+            }
+        },
+        "\/20190206\/tasks\/{task_status}": {
+            "get": {
+                "description": "Return all Tasks for your Stax Organisation.<br\/>Optionally, return all tasks with the specified status for your Stax Organisation.<br\/>A Task may relate to an Account, User, Workload, Organisation or Log Event.<br\/>",
+                "operationId": "tasks.ReadTasks",
+                "parameters": [
+                    {
+                        "description": "Return all tasks of this status.\n\nAccepted values are: RUNNING, SUCCEEDED or FAILED.\n",
+                        "in": "path",
+                        "name": "task_status",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/GetTasks"}
+                            }
+                        },
+                        "description": "The Tasks returned for a valid task_status.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The task_status not supplied or invalid.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch all Tasks by status",
+                "tags": ["Tasks"],
+            }
+        },
+        "\/20190206\/users": {
+            "get": {
+                "description": "Return a list of all Users within your Stax Organisation.<br\/>Optionally, return the requested User.<br\/>",
+                "operationId": "teams.ReadUsers",
+                "parameters": [
+                    {
+                        "description": "The UUID of the User to return.",
+                        "in": "path",
+                        "name": "user_id",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Users filtered by auth origin, comma delimited.\n\nFilter Options available: Team, Federated, Root\n",
+                        "in": "query",
+                        "name": "filter",
+                        "required": false,
+                        "schema": {"default": "Team", "type": "string"},
+                    },
+                    {
+                        "description": "List of User IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Users filtered by Status, comma delimited.\n\nFilter Options available: ACTIVE, NEW, INVITED, DISABLED, DELETED\n",
+                        "in": "query",
+                        "name": "status_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Stax Users, Federated Users, Root Users and API Tokens",
+                "tags": ["Team"],
+            }
+        },
+        "\/20190206\/users\/invite": {
+            "post": {
+                "description": "Invite a new Root User to your Stax Organisation.<br\/>",
+                "operationId": "teams.InviteRootUser",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/teams.InviteRootUser"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "Only Root users can invite new Root users.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Invite New Root User",
+                "tags": ["Team"],
+            }
+        },
+        "\/20190206\/users\/me": {
+            "get": {
+                "description": "Returns the current logged in User.<br\/>",
+                "operationId": "teams.ReadUsers",
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Current User",
+                "tags": ["Team"],
+            }
+        },
+        "\/20190206\/users\/{user_id}": {
+            "delete": {
+                "description": "Delete a Stax User from your Stax Organisation.<br\/>",
+                "operationId": "teams.DeleteUser",
+                "parameters": [
+                    {
+                        "description": "The UUID of the User to delete.",
+                        "in": "path",
+                        "name": "user_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "User not found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete Stax User",
+                "tags": ["Team"],
+            },
+            "get": {
+                "description": "Return a list of all Users within your Stax Organisation.<br\/>Optionally, return the requested User.<br\/>",
+                "operationId": "teams.ReadUsers",
+                "parameters": [
+                    {
+                        "description": "The UUID of the User to return.",
+                        "in": "path",
+                        "name": "user_id",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Users filtered by auth origin, comma delimited.\n\nFilter Options available: Team, Federated, Root\n",
+                        "in": "query",
+                        "name": "filter",
+                        "required": false,
+                        "schema": {"default": "Team", "type": "string"},
+                    },
+                    {
+                        "description": "List of User IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Users filtered by Status, comma delimited.\n\nFilter Options available: ACTIVE, NEW, INVITED, DISABLED, DELETED\n",
+                        "in": "query",
+                        "name": "status_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/teams.ReadUsers"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    }
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Stax Users, Federated Users, Root Users and API Tokens",
+                "tags": ["Team"],
+            },
+        },
+        "\/20190206\/workload-catalogue": {
+            "get": {
+                "description": "Return all Workload Catalogue Items within your Stax Organisation.<br\/>Optionally, return the requested Workload Catalogue Item.<br\/>",
+                "operationId": "workloads.ReadCatalogueItems",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Catalogue Item to return.",
+                        "in": "path",
+                        "name": "catalogue_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The Name of the Workload Catalogue Items to return.",
+                        "in": "query",
+                        "name": "name",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload Catalogue Item statuses you want returned, comma delimited.\n\nFilter options available: STARTED, RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED.\n",
+                        "in": "query",
+                        "name": "filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload Catalogue Item IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Pagination - The page number to return.",
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "Pagination - The number of items per page to return.",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "The field to sort on.",
+                        "in": "query",
+                        "name": "sort",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "Id",
+                                "Name",
+                                "Description",
+                                "Status",
+                                "OrganisationId",
+                                "Public",
+                                "CreatedTS",
+                                "CreatedBy",
+                                "ModifiedTS",
+                                "UserTaskId",
+                                "CatalogueVersionId",
+                                "Protection",
+                            ],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "The sort order - up or down.",
+                        "in": "query",
+                        "name": "sort_order",
+                        "required": false,
+                        "schema": {
+                            "default": "DESC",
+                            "enum": ["ASC", "DESC"],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "Do you want all Versions?",
+                        "in": "query",
+                        "name": "include_versions",
+                        "required": false,
+                        "schema": {"default": true, "type": "boolean"},
+                    },
+                    {
+                        "description": "Do you want the Parameter dictionary?",
+                        "in": "query",
+                        "name": "include_parameters",
+                        "required": false,
+                        "schema": {"default": true, "type": "boolean"},
+                    },
+                    {
+                        "description": "Do you want all the Tags?",
+                        "in": "query",
+                        "name": "include_tags",
+                        "required": false,
+                        "schema": {"default": false, "type": "boolean"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueItems"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if an invalid ID is entered.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if no catalogue is found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Workload Catalogue Items",
+                "tags": ["Workloads"],
+            },
+            "post": {
+                "description": "Create a new Workload Catalogue Item within your Stax Organisation.<br\/>",
+                "operationId": "workloads.CreateCatalogueItem",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/workloads.CreateCatalogueItem"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/CreateCatalogueEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Create Workload Catalogue Item",
+                "tags": ["Workloads"],
+            },
+        },
+        "\/20190206\/workload-catalogue\/manifest\/{version_id}": {
+            "get": {
+                "description": "Return a Workload Catalogue Manifest<br\/>",
+                "operationId": "workloads.ReadCatalogueManifest",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Catalogue Version",
+                        "in": "path",
+                        "name": "version_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueManifest"
+                                }
+                            }
+                        },
+                        "description": "Returns the presigned url for the manifest file",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if an invalid ID is entered.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is not successful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Workload Catalogue Manifest",
+                "tags": ["Workloads"],
+            }
+        },
+        "\/20190206\/workload-catalogue\/template\/{version_id}\/{name}": {
+            "get": {
+                "description": "Return a specific Workload Catalogue Cloudformation Template<br\/>",
+                "operationId": "workloads.ReadCatalogueTemplate",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Catalogue Version",
+                        "in": "path",
+                        "name": "version_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Retrieve the Cloudformation with this Resource Name.",
+                        "in": "path",
+                        "name": "name",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueTemplate"
+                                }
+                            }
+                        },
+                        "description": "Returns the presigned url to retrieve the template",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if an invalid ID is entered.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is not successful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Workload Catalogue Cloudformation Template",
+                "tags": ["Workloads"],
+            }
+        },
+        "\/20190206\/workload-catalogue\/{catalogue_id}": {
+            "delete": {
+                "description": "Delete a Workload Catalogue Item from your Stax Organisation.<br\/>Existing Workloads launched from this Catalogue will not be deleted.<br\/>",
+                "operationId": "workloads.DeleteCatalogueItem",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Catalogue Item to delete.",
+                        "in": "path",
+                        "name": "catalogue_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/DeleteCatalogueEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Workload Catalogue can not be deleted due to running workloads.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Workload Catalogue is Protected. Protection must be disabled before you can delete it.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Workload Catalogue can not be found or does not belong to the user.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete Workload Catalogue Item",
+                "tags": ["Workloads"],
+            },
+            "get": {
+                "description": "Return all Workload Catalogue Items within your Stax Organisation.<br\/>Optionally, return the requested Workload Catalogue Item.<br\/>",
+                "operationId": "workloads.ReadCatalogueItems",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Catalogue Item to return.",
+                        "in": "path",
+                        "name": "catalogue_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The Name of the Workload Catalogue Items to return.",
+                        "in": "query",
+                        "name": "name",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload Catalogue Item statuses you want returned, comma delimited.\n\nFilter options available: STARTED, RUNNING, SUCCEEDED, FAILED, TIMED_OUT, ABORTED.\n",
+                        "in": "query",
+                        "name": "filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload Catalogue Item IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Pagination - The page number to return.",
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "Pagination - The number of items per page to return.",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "The field to sort on.",
+                        "in": "query",
+                        "name": "sort",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "Id",
+                                "Name",
+                                "Description",
+                                "Status",
+                                "OrganisationId",
+                                "Public",
+                                "CreatedTS",
+                                "CreatedBy",
+                                "ModifiedTS",
+                                "UserTaskId",
+                                "CatalogueVersionId",
+                                "Protection",
+                            ],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "The sort order - up or down.",
+                        "in": "query",
+                        "name": "sort_order",
+                        "required": false,
+                        "schema": {
+                            "default": "DESC",
+                            "enum": ["ASC", "DESC"],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "Do you want all Versions?",
+                        "in": "query",
+                        "name": "include_versions",
+                        "required": false,
+                        "schema": {"default": true, "type": "boolean"},
+                    },
+                    {
+                        "description": "Do you want the Parameter dictionary?",
+                        "in": "query",
+                        "name": "include_parameters",
+                        "required": false,
+                        "schema": {"default": true, "type": "boolean"},
+                    },
+                    {
+                        "description": "Do you want all the Tags?",
+                        "in": "query",
+                        "name": "include_tags",
+                        "required": false,
+                        "schema": {"default": false, "type": "boolean"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueItems"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if an invalid ID is entered.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if no catalogue is found.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Workload Catalogue Items",
+                "tags": ["Workloads"],
+            },
+            "put": {
+                "description": "Creates a new version of a Workload Catalogue Item.<br\/>Workload Catalogue Items have one or more versions and are immutable, so any changes are a new version.<br\/>",
+                "operationId": "workloads.CreateCatalogueVersion",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Catalogue Item to update.",
+                        "in": "path",
+                        "name": "catalogue_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/workloads.CreateCatalogueVersion"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/CreateVersionEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Workload Catalogue Item",
+                "tags": ["Workloads"],
+            },
+        },
+        "\/20190206\/workload-catalogue\/{catalogue_id}\/{version_id}": {
+            "delete": {
+                "description": "Delete a Workload Catalogue Version from your Stax Organisation.<br\/>Existing Workloads launched from this Workload Catalogue Version will not be deleted.<br\/>",
+                "operationId": "workloads.DeleteCatalogueVersion",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Catalogue Item.",
+                        "in": "path",
+                        "name": "catalogue_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The UUID of the Catalogue Version to delete.",
+                        "in": "path",
+                        "name": "version_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/DeleteVersionEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Workload Catalogue Version can not be deleted due to running workloads.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Workload Catalogue Version can not be found or does not belong to the user.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Delete Workload Catalogue Version",
+                "tags": ["Workloads"],
+            },
+            "get": {
+                "description": "Return a specific Workload Catalogue Version.<br\/>",
+                "operationId": "workloads.ReadCatalogueVersion",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Catalogue Item to return.",
+                        "in": "path",
+                        "name": "catalogue_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The UUID of the Catalogue Version to return.",
+                        "in": "path",
+                        "name": "version_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Do you want the Parameter dictionary?",
+                        "in": "query",
+                        "name": "include_parameters",
+                        "required": false,
+                        "schema": {"default": true, "type": "boolean"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/workloads.ReadCatalogueVersion"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if an invalid ID is entered.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is not successful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Workload Catalogue Version",
+                "tags": ["Workloads"],
+            },
+        },
+        "\/20190206\/workload-update": {
+            "post": {
+                "deprecated": true,
+                "description": "(DEPRECATED) Update all active Workloads for a specific Workload Catalogue Item.<br\/>",
+                "operationId": "workloads.UpdateAll",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/workloads.UpdateAll"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the Catalogue is not owned by the User.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update All Workloads",
+                "tags": ["Workloads", "Deprecated"],
+            }
+        },
+        "\/20190206\/workloads": {
+            "get": {
+                "description": "Return a list of all Workloads available within your Stax Organisation.<br\/>Optionally, return the requested Workload.<br\/>",
+                "operationId": "workloads.ReadWorkloads",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Workload Item to return.",
+                        "in": "path",
+                        "name": "workload_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The Name of the Workloads to return.",
+                        "in": "query",
+                        "name": "name",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: NEW, INITIALIZING, ACTIVE, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED, UPDATE_IN_PROGRESS, UPDATE_FAILED, UPDATE_COMPLETE.\n",
+                        "in": "query",
+                        "name": "filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Only return Workloads launched from this Catalogue Version.",
+                        "in": "query",
+                        "name": "catalogue_version_id",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Pagination - The page number to return. Must be used with limit",
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "Pagination - The number of items per page to return. Must be used with offset",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "The field to sort on.",
+                        "in": "query",
+                        "name": "sort",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "Id",
+                                "Name",
+                                "AccountId",
+                                "CatalogueId",
+                                "CatalogueVersionId",
+                                "Region",
+                                "Status",
+                                "UserTaskId",
+                                "CreatedBy",
+                                "CreatedTS",
+                                "ModifiedTS",
+                                "FactoryVersion",
+                            ],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "The sort order - up or down.",
+                        "in": "query",
+                        "name": "sort_order",
+                        "required": false,
+                        "schema": {
+                            "default": "DESC",
+                            "enum": ["ASC", "DESC"],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "Do you want all the Tags?",
+                        "in": "query",
+                        "name": "include_tags",
+                        "required": false,
+                        "schema": {"default": false, "type": "boolean"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/workloads.ReadWorkloads"
+                                }
+                            }
+                        },
+                        "description": "A list of all Workloads for the logged in Customer.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the Workload ID is not a valid UUID.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the Workload ID does not exist.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Workloads",
+                "tags": ["Workloads"],
+            },
+            "post": {
+                "description": "Deploy a Workload within an AWS Account.<br\/>",
+                "operationId": "workloads.CreateWorkload",
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {"$ref": "#\/components\/schemas\/Workload"}
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/CreateWorkloadEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Deploy Workload",
+                "tags": ["Workloads"],
+            },
+        },
+        "\/20190206\/workloads\/{workload_id}": {
+            "delete": {
+                "description": "Terminate an active Workload within an AWS Account.<br\/>",
+                "operationId": "workloads.DeleteWorkload",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Workload to delete.",
+                        "in": "path",
+                        "name": "workload_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/DeleteWorkloadEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                    "403": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The Workload is Protected. Protection must be disabled before you can delete it.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The Workload can not be found or does not belong to the user.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Terminate Workload",
+                "tags": ["Workloads"],
+            },
+            "get": {
+                "description": "Return a list of all Workloads available within your Stax Organisation.<br\/>Optionally, return the requested Workload.<br\/>",
+                "operationId": "workloads.ReadWorkloads",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Workload Item to return.",
+                        "in": "path",
+                        "name": "workload_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "The Name of the Workloads to return.",
+                        "in": "query",
+                        "name": "name",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload statuses you want returned, comma delimited.\n\nFilter Options available: NEW, INITIALIZING, ACTIVE, CREATE_FAILED, DELETE_IN_PROGRESS, DELETED, DELETE_FAILED, UPDATE_IN_PROGRESS, UPDATE_FAILED, UPDATE_COMPLETE.\n",
+                        "in": "query",
+                        "name": "filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "List of Workload IDs you want returned, comma delimited.",
+                        "in": "query",
+                        "name": "id_filter",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Only return Workloads launched from this Catalogue Version.",
+                        "in": "query",
+                        "name": "catalogue_version_id",
+                        "required": false,
+                        "schema": {"type": "string"},
+                    },
+                    {
+                        "description": "Pagination - The page number to return. Must be used with limit",
+                        "in": "query",
+                        "name": "offset",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "Pagination - The number of items per page to return. Must be used with offset",
+                        "in": "query",
+                        "name": "limit",
+                        "required": false,
+                        "schema": {"type": "integer"},
+                    },
+                    {
+                        "description": "The field to sort on.",
+                        "in": "query",
+                        "name": "sort",
+                        "required": false,
+                        "schema": {
+                            "enum": [
+                                "Id",
+                                "Name",
+                                "AccountId",
+                                "CatalogueId",
+                                "CatalogueVersionId",
+                                "Region",
+                                "Status",
+                                "UserTaskId",
+                                "CreatedBy",
+                                "CreatedTS",
+                                "ModifiedTS",
+                                "FactoryVersion",
+                            ],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "The sort order - up or down.",
+                        "in": "query",
+                        "name": "sort_order",
+                        "required": false,
+                        "schema": {
+                            "default": "DESC",
+                            "enum": ["ASC", "DESC"],
+                            "type": "string",
+                        },
+                    },
+                    {
+                        "description": "Do you want all the Tags?",
+                        "in": "query",
+                        "name": "include_tags",
+                        "required": false,
+                        "schema": {"default": false, "type": "boolean"},
+                    },
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/workloads.ReadWorkloads"
+                                }
+                            }
+                        },
+                        "description": "A list of all Workloads for the logged in Customer.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the Workload ID is not a valid UUID.",
+                    },
+                    "404": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/Error"}
+                            }
+                        },
+                        "description": "The response returned if the Workload ID does not exist.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Fetch Workloads",
+                "tags": ["Workloads"],
+            },
+            "put": {
+                "description": "Update a Workload running within an AWS Account.<br\/>",
+                "operationId": "workloads.UpdateWorkload",
+                "parameters": [
+                    {
+                        "description": "The UUID of the Workload to update.",
+                        "in": "path",
+                        "name": "workload_id",
+                        "required": true,
+                        "schema": {"type": "string"},
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application\/json": {
+                            "schema": {
+                                "$ref": "#\/components\/schemas\/workloads.UpdateWorkload"
+                            }
+                        }
+                    },
+                    "required": true,
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {
+                                    "$ref": "#\/components\/schemas\/UpdateWorkloadEvent"
+                                }
+                            }
+                        },
+                        "description": "The response returned if the request is successful.",
+                    },
+                    "400": {
+                        "content": {
+                            "application\/json": {
+                                "schema": {"$ref": "#\/components\/schemas\/StaxEvent"}
+                            }
+                        },
+                        "description": "The response returned if the request is unsuccessful.",
+                    },
+                },
+                "security": [{"sigv4": []}],
+                "summary": "Update Workload",
+                "tags": ["Workloads"],
+            },
+        },
+    },
+    "servers": [{"url": "https:\/\/api.au1.staxapp.cloud"}],
 }

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ nose2 -v basics
 """
 
 import unittest
+from unittest.mock import patch
 import jwt
 import botocore
 import requests
@@ -156,7 +157,7 @@ class StaxAuthTests(unittest.TestCase):
                 expected_params=expected_parameters,
             )
         self.cognito_stub.activate()
-        
+
         with self.assertRaises(InvalidCredentialsException) as e:
             sa.sts_from_cognito_identity_pool(jwt_token.get("sub"), cognito_client=self.cognito_client)
 
@@ -305,6 +306,37 @@ class StaxAuthTests(unittest.TestCase):
         )
         self.assertIsNotNone(StaxConfig.auth)
 
+
+    @patch("test_auth.StaxAuth.requests_auth")
+    def testApiTokenAuthExpiring(self, requests_auth_mock):
+        """
+        Test credentials close to expiration get refreshed
+        """
+        sa = StaxAuth("ApiAuth")
+        StaxConfig = Config
+        ## expiration 20 minutes in the future, no need to refresh
+        StaxConfig.expiration = datetime.now(timezone.utc) + timedelta(minutes=20)
+
+        ApiTokenAuth.requests_auth(
+            "username",
+            "password",
+            srp_client=self.aws_srp_client,
+            cognito_client=self.cognito_client,
+        )
+        requests_auth_mock.assert_not_called()
+
+        requests_auth_mock.reset_mock()
+        ## expiration in 5 minutes from now, refresh to avoid token becoming stale used
+        StaxConfig.expiration = datetime.now(timezone.utc) + timedelta(minutes=5)
+
+        ApiTokenAuth.requests_auth(
+            "username",
+            "password",
+            srp_client=self.aws_srp_client,
+            cognito_client=self.cognito_client,
+        )
+        requests_auth_mock.assert_called_once()
+
     def testRootAuthNotExpired(self):
         """
         Test credentials have not expired
@@ -357,6 +389,7 @@ class StaxAuthTests(unittest.TestCase):
             srp_client=self.aws_srp_client, cognito_client=self.cognito_client,
         )
         self.assertIsNotNone(Api._requests_auth)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There is currently no buffer on the time after getting tokens.
That being said, if you complete the `.requests_auth` flow and the token expired 1 second after that - you're running around with an expired set of creds being none the wiser.

Example out in the wild:
![image](https://user-images.githubusercontent.com/17537115/115184610-84446680-a121-11eb-945e-06556c3aa43b.png)
