### PR TITLE
feat(GetPublicConfig): allow backoff and retry when getting public config URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ Allows configuration of the threshold to when the Auth library should re-cache t
 *Suggested use when running within CI/CD tools to reduce overall auth calls*
 ~~~bash
 export TOKEN_EXPIRY_THRESHOLD_IN_MINS=2 # Type: Integer representing minutes
+export CONFIG_BACKOFF_RATE=2 # Type: Float representing rate at which to extend backoff
+export CONFIG_INITIAL_WAIT=2 # Type: Float representing initial wait before retry
+export CONFIG_RETRY_LIMIT=2 # Type: Int representing number of retries before failing
 ~~~
+
+*CONFIG_* prefix is used for values used when receiving the public config data.
+This URL is prone to WAF interception which will block these requests.
 
 ## Usage
 


### PR DESCRIPTION
currently this call is prone to WAF protection


~~~
2021-04-29T08:01:32.452+10:00
\[ERROR] ApiException: Api Exception: Could not load API config. 403 Client Error: Forbidden for url: https://api.us1.staxapp.cloud/20190206/public/config Traceback (most recent call last):   File "/var/lang/lib/python3.7/imp.py", line 234, in load_module     return load_source(name, filename, file)   File "/var/lang/lib/python3.7/imp.py", line 171, in load_source     module = _load(spec)   File "<frozen importlib._bootstrap>", line 696, in _load   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked   File "<frozen importlib._bootstrap_external>", line 728, in exec_module   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed   File "/var/task/deploy_workload.py", line 22, in <module>     from staxapp.config import Config as StaxConfig   File "/var/task/staxapp/config.py", line 87, in <module>     Config.init()   File "/var/task/staxapp/config.py", line 62, in init     cls.set_config()   File "/var/task/staxapp/config.py", line 51, in set_config     str(e), config_response, detail=" Could not load API config."
~~~