### PR TITLE
feat(Logs): allow configuration of logging levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[Python - Logging Levels]:https://docs.python.org/3/library/logging.html#levels
 # Stax SDK for Python
 `staxapp` is the [Stax](https://stax.io) Software Development Kit (SDK) for Python, allowing users to interact with the Stax platform.
 
@@ -5,7 +6,7 @@
 ![build](https://github.com/stax-labs/lib-stax-python-sdk/workflows/build/badge.svg)
 ![deploy](https://github.com/stax-labs/lib-stax-python-sdk/workflows/deploy/badge.svg)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/staxapp)
-![Python - Logging Levels](https://docs.python.org/3/library/logging.html#levels)
+
 ## Authentication
 In order to use the Stax SDK for Python, you will need a valid [Stax API Token](https://www.stax.io/developer/api-tokens/).
 
@@ -37,6 +38,8 @@ export TOKEN_EXPIRY_THRESHOLD_IN_MINS=2 # Type: Integer representing minutes
 As the logging levels are set on the import of the `Config` module, the below configuration is available on the presense of following environment variables:
 
 - LOG_LEVEL: Default logger level
+
+Value of environment variables should match [Python - Logging Levels]
 
 Example:
 ~~~bash

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ As the logging levels are set on the import of the `Config` module, the below co
 Value of environment variables should match [Python - Logging Levels]
 
 Example:
+Changing the logging from `INFO` to `DEBUG`
 ~~~bash
-export LOG_LEVEL=INFO
+export LOG_LEVEL=DEBUG
 python run_example.py
 ~~~
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![build](https://github.com/stax-labs/lib-stax-python-sdk/workflows/build/badge.svg)
 ![deploy](https://github.com/stax-labs/lib-stax-python-sdk/workflows/deploy/badge.svg)
 ![PyPI - Python Version](https://img.shields.io/pypi/pyversions/staxapp)
+![Python - Logging Levels](https://docs.python.org/3/library/logging.html#levels)
 ## Authentication
 In order to use the Stax SDK for Python, you will need a valid [Stax API Token](https://www.stax.io/developer/api-tokens/).
 
@@ -29,6 +30,18 @@ Allows configuration of the threshold to when the Auth library should re-cache t
 *Suggested use when running within CI/CD tools to reduce overall auth calls*
 ~~~bash
 export TOKEN_EXPIRY_THRESHOLD_IN_MINS=2 # Type: Integer representing minutes
+~~~
+
+##### Logging levels
+
+As the logging levels are set on the import of the `Config` module, the below configuration is available on the presense of following environment variables:
+
+- LOG_LEVEL: Default logger level
+
+Example:
+~~~bash
+export LOG_LEVEL=INFO
+python run_example.py
 ~~~
 
 ## Usage

--- a/staxapp/config.py
+++ b/staxapp/config.py
@@ -9,6 +9,7 @@ from staxapp.exceptions import ApiException
 
 logging.getLogger().setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
 
+
 class Config:
     """
     Insert doco here

--- a/staxapp/config.py
+++ b/staxapp/config.py
@@ -7,8 +7,7 @@ import requests
 import staxapp
 from staxapp.exceptions import ApiException
 
-logging.getLogger().setLevel(logging.DEBUG)
-
+logging.getLogger().setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
 
 class Config:
     """

--- a/staxapp/config.py
+++ b/staxapp/config.py
@@ -7,7 +7,7 @@ import requests
 import staxapp
 from staxapp.exceptions import ApiException
 
-logging.getLogger().setLevel(os.environ.get("LOG_LEVEL", logging.DEBUG))
+logging.getLogger().setLevel(os.environ.get("LOG_LEVEL", logging.INFO))
 
 
 class Config:


### PR DESCRIPTION
* Feature - Logging Levels

* Current behaviour

Currently, this library unapologetically sets log levels across all loggers without configuration.
Results in all modules (outside of this library) logging in DEBUG, eg:
~~~
DEBUG:pynamodb.connection.base:Calling GetItem with arguments ....
~~~

* **Does this PR introduce a breaking change?** 

I would love to set some more sensible defaults, but have left the defaults as the original authors intended.
New functionaility will allow users customize to their preference
