### PR TITLE
Don't set log level for other packages

### DIFF
--- a/staxapp/config.py
+++ b/staxapp/config.py
@@ -8,10 +8,6 @@ import staxapp
 from staxapp.exceptions import ApiException
 
 logging.getLogger().setLevel(logging.DEBUG)
-logging.getLogger("boto3").setLevel(logging.WARNING)
-logging.getLogger("botocore").setLevel(logging.WARNING)
-logging.getLogger("nose").setLevel(logging.WARNING)
-logging.getLogger("urllib3").setLevel(logging.WARNING)
 
 
 class Config:


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

change global configuration setting

* **What is the current behavior?** (You can also link to an open issue here)

we are setting the log level for other packages boto, botocore and urllib3

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

features will still work but anyone who was using our lib to set boto log levels will need to do it themselves
