### PR TITLE
Add response content to ApiException class

### DIFF
--- a/staxapp/exceptions.py
+++ b/staxapp/exceptions.py
@@ -6,6 +6,7 @@ class ApiException(Exception):
     def __init__(self, message, response, detail=""):
         try:
             self.status_code = response.status_code
+            self.response = response.json()
             if response.json().get("Error"):
                 logging.error(f"{response.status_code}: {response.json()}")
                 self.message = f"Api Exception: {response.status_code} -{detail} {response.json()['Error']}"
@@ -15,6 +16,7 @@ class ApiException(Exception):
         except:
             if response.content:
                 logging.error(f"{response.status_code}: {response.content}")
+                self.response = response.content
             else:
                 logging.error(f"{response.status_code}: {message}")
             self.message = f"Api Exception:{detail} {message}"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

adds a response field to the staxapp.exceptions.ApiException class, this allows users to use the response even in error scenarios, an example might be when creating an account type that already exists the API returns HTTP/400 which the SDK raises an exception for, however the api returns the details about the existing account-type but doesn't pass them back to the calling code.

example
```python
    except ApiException as e:
        if e.status_code == 400:
            print(e.response['Detail']['AccountType']['Id'])
```


this means the user needs to make another get call just to get the existing ID

* **What is the current behavior?** (You can also link to an open issue here)

the response data (json or otherwise) is logged but not stored meaning users need to make a second call or attempt to string parse the logs 🙅 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

no - this only adds a new attribute to an existing class
