### PR TITLE
feat(Config): not init on import of module

### DIFF
--- a/staxapp/config.py
+++ b/staxapp/config.py
@@ -50,7 +50,9 @@ class Config:
         cls.api_config = config_response.json()
 
     @classmethod
-    def init(cls, config=None):
+    def init(cls, config=None, hostname=None):
+        if hostname is not None:
+            cls.hostname = hostname
         if cls._initialized:
             return
 
@@ -78,6 +80,3 @@ class Config:
 
             cls.auth_class = ApiTokenAuth
         return cls.auth_class
-
-
-Config.init()

--- a/staxapp/openapi.py
+++ b/staxapp/openapi.py
@@ -15,8 +15,10 @@ class StaxClient:
     _schema = dict()
     _initialized = False
 
-    def __init__(self, classname, force=False):
+    def __init__(self, classname, force=False, Config=Config):
         # Stax feature, eg 'quotas', 'workloads'
+        if not Config._initialized:
+            Config.init()
         if force or not self._operation_map:
             _operation_map = dict()
             self._map_paths_to_operations()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,7 @@ class StaxApiTests(unittest.TestCase):
     def setUp(self):
         self.Api = Api
         self.Api._requests_auth = lambda x, y: (x, y)
+        Config.init()
 
     def testAuth(self):
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,6 +7,7 @@ nose2 -v basics
 
 import responses
 import unittest
+from unittest.mock import patch
 
 from staxapp.api import Api
 from staxapp.config import Config
@@ -28,12 +29,17 @@ class StaxClientTests(unittest.TestCase):
         self.assertTrue(self.account_client._initialized)
         self.assertTrue(self.workload_client._initialized)
 
-    def testStaxClient(self):
+    @patch("staxapp.config.Config.init")
+    def testStaxClient(self, Config_init_mock):
         """
         Test initializing Stax client
         """
         client = StaxClient("accounts")
         self.assertTrue(client._initialized)
+
+        Config._initialized = False
+        client = StaxClient("accounts")
+        Config_init_mock.assert_called_once()
 
     def testInvalidStaxClient(self):
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ nose2 -v basics
 """
 
 import unittest
+from unittest.mock import patch
 import responses
 
 from staxapp.auth import ApiTokenAuth
@@ -21,6 +22,20 @@ class StaxConfigTests(unittest.TestCase):
     def setUp(self):
         self.Config = Config
         self.Config.init()
+
+    @patch("staxapp.config.Config.set_config")
+    def testInit(self, set_config_mock):
+        """
+        Test init method
+        """
+        self.Config._initialized = False
+        test_hostname = "test.staxapp.cloud"
+        self.Config.init(hostname=test_hostname)
+        self.assertEqual(
+            test_hostname,
+            self.Config.hostname,
+        )
+        set_config_mock.assert_called_once()
         self.assertTrue(self.Config._initialized)
 
     @responses.activate


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Changing the default behaviour of the Config module
Allowing the hostname for the class to be changed on the init method (vs modifying the environment variables)

* **What is the current behavior?** (You can also link to an open issue here)

Current behaviour has the module class setup on import - this lends itself to some undesirable code (by moving the import into further down, conditionally doing imports as it cannot be modified after import)

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

~~~

In [1]: from staxapp.config import Config
   ...: from staxapp.openapi import StaxClient

In [2]: Config.secret_key = "xxx"

In [3]: Config.access_key = "yyy"

In [4]: stax_workloads = StaxClient("workloads", Config=Config)

In [5]: len(stax_workloads.ReadWorkloads(filter='ACTIVE')["Workloads"])
Out[5]: 742
~~~

Or 

~~~

In [4]: stax_workloads = StaxClient("workloads")

In [5]: len(stax_workloads.ReadWorkloads(filter='ACTIVE')["Workloads"])
Out[5]: 742
~~~