### PR TITLE
remove print statement from auth module

### DIFF
--- a/staxapp/auth.py
+++ b/staxapp/auth.py
@@ -152,7 +152,6 @@ class ApiTokenAuth:
     @staticmethod
     def requests_auth(config: StaxConfig, **kwargs):
         # Minimize the potential for token to expire while still being used for auth (say within a lambda function)
-        print(config.api_auth_retry_config.token_expiry_threshold)
         if config.expiration and config.expiration - timedelta(
             minutes=config.api_auth_retry_config.token_expiry_threshold
         ) > datetime.now(timezone.utc):


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
`requests_auth` module prints `token_expiry_threshold` to stdout. Fixes bug issue raised https://github.com/stax-labs/lib-stax-python-sdk/issues/90

* **What is the current behavior?** (You can also link to an open issue here)
* Prints `token_expiry_threshold` to stdout.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No