### PR TITLE
chore(deps): unpin pyjwt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ pytest
 pytest-cov
 responses
 requests
-pyjwt==2.4.0
+pyjwt
 boto3
 aws_requests_auth
 openapi-spec-validator==0.2.9

--- a/staxapp/aws_srp.py
+++ b/staxapp/aws_srp.py
@@ -1,20 +1,20 @@
 """
-   Copyright 2021 Brian Jinwright <opensource@capless.io>
+Copyright 2021 Brian Jinwright <opensource@capless.io>
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
-   Imported from https://github.com/capless/warrant to reduce external dependencies required by this library and just
-   use the SRP functions.
+Imported from https://github.com/capless/warrant to reduce external dependencies required by this library and just
+use the SRP functions.
 """
 
 import base64


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
  * This PR simply unpins PyJWT. The version as pinned (2.4.0) has been raised by Dependabot as potentially high vulnerability. Although this appears to only affect test code (which otherwise runs fine), there wasn't really any good reason to pin this dependency in the first place.

* **What is the current behavior?**
  * There is no change in behaviour, as PyJWT is only used in test code in this repo.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
  * No. As aforementioned, the change will only affect test code, which I have run locally.