### PR TITLE
fix(platform): use new build commands

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pipenv setuptools wheel twine
+          pip install build setuptools wheel twine
       - name: Build
         run: |
-          pipenv run python setup.py sdist bdist_wheel
+          python -m build
       - name: Publish distribution 📦 to Test PyPI
         if: github.event.release.prerelease == true
         uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # 1.8.14

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ test: lint
 install:
 	python3 -m venv ${VIRTUAL_ENV}
 	${PIP} install -r requirements.txt
-	${PYTHON} setup.py install
+	${PIP} install .
 
 lint: install
 	${ISORT} --diff staxapp/*.py
@@ -37,7 +37,7 @@ download-schema:
 
 
 bundle-test: install
-	${PIP} install twine
-	${PYTHON} setup.py sdist
+	${PIP} install build twine
+	${PYTHON} -m build
 	${VIRTUAL_ENV}/bin/twine check dist/*
 	${VIRTUAL_ENV}/bin/twine upload --repository-url https://test.pypi.org/legacy/ dist/*

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requires = [
     "prance",
     "requests",
     "aws_requests_auth",
-    "openapi-spec-validator==0.2.9",
+    "openapi-spec-validator",
 ]
 
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Uses new build commands instead of invoking `setup.py` directly. This is a deprecated pattern, so we would like to move away from it if possible. This pattern has been deprecated for a very long time now, but at least there is some [documentation](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html) making the changeover rather seamless.

* **What is the current behavior?**
`setup.py` is called for various build commands, and there are no significant issues. Coincidentally, our 1.4.0 release build is failing due to missing `setuptools` (see [here](https://github.com/stax-labs/lib-stax-python-sdk/actions/runs/25300540766/job/74166600641#step:6:39)), but rather than simply making sure `setuptools` is installed I figured it would be better to use the newer pattern anyway.

* **Does this PR introduce a breaking change?**
The PR should not introduce any breaking changes. In fact, this PR should at least fix the build failure that we're currently experiencing.
