### PR TITLE
fix(platform): use gh-action-pypi-publish 1.14.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,12 +24,12 @@ jobs:
           python -m build
       - name: Publish distribution 📦 to Test PyPI
         if: github.event.release.prerelease == true
-        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # 1.8.14
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # 1.14.0
         with:
           password: ${{ secrets.TEST_PYPI_PASSWORD }}
           repository_url: https://test.pypi.org/legacy/
       - name: Publish distribution 📦 to PyPI
         if: github.event.release.prerelease != true
-        uses: pypa/gh-action-pypi-publish@81e9d935c883d0b210363ab89cf05f3894778450 # 1.8.14
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # 1.14.0
         with:
           password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Bumps pypa/gh-action-pypi-publish in our deploy jobs so that we can hopefully finally push packages to PyPI. Because we're using the latest version of twine in our builds, in conjunction to it being a very long time since the last version of the staxapp package was published, our wheels produce metadata that isn't recognised by the version of pypa/gh-action-pypi-publish. The version we've been using up to that point supports wheel metadata versions <=2.3, whereas we currently generate wheels with a metadata version of 2.4.

* **What is the current behavior?**
Attempting to publish to PyPI will produce the following error:

```
InvalidDistribution: Metadata is missing required fields: Version.
Make sure the distribution includes the files where those fields specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2, 2.0, 2.1, 2.2, 2.3.
```

* **Does this PR introduce a breaking change?**
I don't believe it would. Because it's been so long since the last release, I'm more convinced that we're fixing what's been since broken.